### PR TITLE
Fix Scientist and Rejector roles/groups missing in new instances

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0
 -----
 
+- #26 Fix Scientist and Rejector roles/groups missing in new instances
 - #23 Add a department filter bar in samples listing
 - #13 Setup whonet report
 - #9 Added Rejector role and Rejectors group

--- a/src/bes/lims/profiles/default/metadata.xml
+++ b/src/bes/lims/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>1007</version>
+  <version>1008</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/bes/lims/setuphandlers.py
+++ b/src/bes/lims/setuphandlers.py
@@ -20,6 +20,7 @@
 
 from bes.lims import logger
 from bes.lims import permissions
+from bes.lims import PRODUCT_NAME
 from bika.lims import api
 from bika.lims.api import security as sapi
 from plone import api as ploneapi
@@ -144,12 +145,19 @@ def setup_handler(context):
     logger.info("BES setup handler [BEGIN]")
 
     portal = context.getSite()
+    setup = portal.portal_setup  # noqa
+
+    # Run required import steps
+    profile = "profile-{0}:default".format(PRODUCT_NAME)
+    setup.runImportStepFromProfile(profile, "actions")
+    setup.runImportStepFromProfile(profile, "rolemap")
+    setup.runImportStepFromProfile(profile, "skins")
 
     # Setup roles
-    #setup_roles(portal)
+    setup_roles(portal)
 
     # Setup groups
-    #setup_groups(portal)
+    setup_groups(portal)
 
     # Setup Catalogs
     setup_catalogs(portal)

--- a/src/bes/lims/upgrade/v01_00_000.zcml
+++ b/src/bes/lims/upgrade/v01_00_000.zcml
@@ -3,6 +3,14 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="Setup product-specific roles and groups"
+      description="Setup product-specific roles and groups"
+      source="1007"
+      destination="1008"
+      handler=".v01_00_000.setup_roles_and_groups"
+      profile="bes.lims:default"/>
+
+  <genericsetup:upgradeStep
       title="Setup department filtering functionality"
       description="Setup department filtering functionality"
       source="1006"


### PR DESCRIPTION
## Description

This Pull Request ensures that the product-specific roles `Scientist` and `Rejector` are added on install. It also adds an upgrade step to add the roles and groups on new instances.

## Current behavior

`Scientist` and `Rejector` roles are missing on new instances

## Desired behavior

`Scientist` and `Rejector` roles are missing on new instances

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
