### PR TITLE
Display patient age in "Analyses results" stat report

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0
 -----
 
+- #27 Display patient age in "Analyses results" stat report
 - #26 Fix Scientist and Rejector roles/groups missing in new instances
 - #23 Add a department filter bar in samples listing
 - #13 Setup whonet report

--- a/src/bes/lims/reports/forms/analyses_results.py
+++ b/src/bes/lims/reports/forms/analyses_results.py
@@ -27,7 +27,6 @@ from bes.lims.reports.forms import CSVReport
 from bes.lims.utils import is_reportable
 from bika.lims import api
 from senaite.core.api import dtime
-from senaite.core.api.dtime import get_relative_delta
 from senaite.core.catalog import SAMPLE_CATALOG
 from senaite.patient.api import get_age_ymd
 from senaite.patient.config import SEXES


### PR DESCRIPTION
## Description

This Pull Request adds the column "Patient age" in "Analysis results" stat report. The age is truncated to the highest period.

Linked issue: #27

## Current behavior

Age is not present in the "Analysis results" stat report

## Desired behavior

Age is present in the "Analysis results" stat report

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
