### PR TITLE
Add an "All" button to the department filter bar

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.0.0
 -----
 
-- #27 Display patient age in "Analyses results" stat report
+- #30 Add an "All" button to the department filter bar
+- #29 Display patient age in "Analyses results" stat report
 - #26 Fix Scientist and Rejector roles/groups missing in new instances
 - #23 Add a department filter bar in samples listing
 - #13 Setup whonet report

--- a/src/bes/lims/browser/departmentfilter/templates/departmentfilter.pt
+++ b/src/bes/lims/browser/departmentfilter/templates/departmentfilter.pt
@@ -27,6 +27,13 @@
       </tal:checkbox>
     </div>
 
+    <!-- All departments option -->
+    <button type="submit" 
+              name="all_departments"
+              value="all_departments"
+              class="btn btn-sm btn-outline-primary ml-2"
+              i18n:translate="">All</button>
+
     <button type="submit" i18n:translate=""
             class="btn btn-sm btn-outline-primary ml-2">Apply</button>
 

--- a/src/bes/lims/browser/departmentfilter/viewlet.py
+++ b/src/bes/lims/browser/departmentfilter/viewlet.py
@@ -94,12 +94,24 @@ class DepartmentFilteringViewlet(ViewletBase):
         return True if departments else False
 
     def render(self):
-        # Handle manual selection of departments
-        departments = self.request.form.get("departments", None)
-        if departments is None:
+        # Check if form was submitted
+        form_submitted = (
+            "departments" in self.request.form
+            or "all_departments" in self.request.form
+        )
+        if not form_submitted:
             return self.index()
 
         contact = self.get_current_contact()
+
+        all_departments = self.request.form.get("all_departments", None)
+        if all_departments:
+            # Get all available departments
+            departments = get_allowed_departments(contact)
+        else:
+            # Otherwise use the selected departments
+            departments = self.request.form.get("departments", [])
+
         set_selected_departments(contact, departments)
 
         return self.index()


### PR DESCRIPTION
## Description
This Pull Request adds an "All" option in the lab department filter on the sample dashboard. 

Linked issue: https://github.com/beyondessential/bes.lims/issues/24

## Current behavior
Currently, users must manually select multiple departments to view samples from all departments. There is no quick way to display all samples at once.

## Desired behavior

- Add an "All" option at the end of the department list, next to "No department."
- When selected, "All" will automatically include all departments in the filter.
- The sample listing will display all samples across departments while respecting other filters (e.g., "Active," "Due").

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
