### PR TITLE
Flat listing for default, due, received, to be verified and verified samples

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0
 -----
 
+- #31 Flat listing for default, due, received, to be verified and verified samples
 - #30 Add an "All" button to the department filter bar
 - #29 Display patient age in "Analyses results" stat report
 - #26 Fix Scientist and Rejector roles/groups missing in new instances

--- a/src/bes/lims/adapters/__init__.py
+++ b/src/bes/lims/adapters/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of BES.LIMS.
+#
+# BES.LIMS is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2024-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.

--- a/src/bes/lims/adapters/configure.zcml
+++ b/src/bes/lims/adapters/configure.zcml
@@ -1,0 +1,6 @@
+<configure xmlns="http://namespaces.zope.org/zope">
+
+  <!-- Package includes -->
+  <include package=".listing" />
+
+</configure>

--- a/src/bes/lims/adapters/listing/__init__.py
+++ b/src/bes/lims/adapters/listing/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of BES.LIMS.
+#
+# BES.LIMS is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2024-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.

--- a/src/bes/lims/adapters/listing/configure.zcml
+++ b/src/bes/lims/adapters/listing/configure.zcml
@@ -3,8 +3,8 @@
     i18n_domain="bes.lims">
 
   <subscriber
-    for="bika.lims.browser.analysisrequest.AnalysisRequestsView
-         bika.lims.interfaces.IAnalysisRequestsFolder"
+    for="senaite.core.browser.samples.view.SamplesView
+         *"
     provides="senaite.app.listing.interfaces.IListingViewAdapter"
     factory=".samples.SamplesListingAdapter" />
 

--- a/src/bes/lims/adapters/listing/configure.zcml
+++ b/src/bes/lims/adapters/listing/configure.zcml
@@ -1,0 +1,11 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    i18n_domain="bes.lims">
+
+  <subscriber
+    for="bika.lims.browser.analysisrequest.AnalysisRequestsView
+         bika.lims.interfaces.IAnalysisRequestsFolder"
+    provides="senaite.app.listing.interfaces.IListingViewAdapter"
+    factory=".samples.SamplesListingAdapter" />
+
+</configure>

--- a/src/bes/lims/adapters/listing/samples.py
+++ b/src/bes/lims/adapters/listing/samples.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of BES.LIMS.
+#
+# BES.LIMS is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2024-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from senaite.app.listing.interfaces import IListingView
+from senaite.app.listing.interfaces import IListingViewAdapter
+from zope.component import adapts
+from zope.interface import implements
+
+# Statuses to update. List of tuples (status_id, {properties})
+UPDATE_STATUSES = [
+    ("default", {
+        "flat_listing": True,
+    }),
+    ("sample_due", {
+        "flat_listing": True,
+    }),
+    ("sample_received", {
+        "flat_listing": True,
+    }),
+    ("to_be_verified", {
+        "flat_listing": True,
+    }),
+    ("verified", {
+        "flat_listing": True,
+    })
+]
+
+
+class SamplesListingAdapter(object):
+    """Generic adapter for sample listings
+    """
+    adapts(IListingView)
+    implements(IListingViewAdapter)
+
+    # Priority order of this adapter over others
+    priority_order = 9999
+
+    def __init__(self, listing, context):
+        self.listing = listing
+        self.context = context
+
+    def folder_item(self, obj, item, index):
+        return item
+
+    def before_render(self):
+        # Update review_states
+        states_to_update = dict(UPDATE_STATUSES)
+        for rv in self.listing.review_states:
+            values = states_to_update.get(rv["id"], {})
+            rv.update(values)

--- a/src/bes/lims/configure.zcml
+++ b/src/bes/lims/configure.zcml
@@ -19,6 +19,7 @@
   <include file="vocabularies.zcml"/>
 
   <!-- Package includes -->
+  <include package=".adapters"/>
   <include package=".behaviors"/>
   <include package=".browser"/>
   <include package=".catalog"/>


### PR DESCRIPTION
## Description

Linked issue: https://github.com/beyondessential/bes.lims/issues/16

## Current behavior
Samples listing in nested mode by default

## Desired behavior
Samples listing in flat mode for default, due, received, to be verified and verified samples

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
