### PR TITLE
Do not display stickers from senaite namespace

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0
 -----
 
+- #32 Do not display stickers from senaite namespace
 - #31 Flat listing for default, due, received, to be verified and verified samples
 - #30 Add an "All" button to the department filter bar
 - #29 Display patient age in "Analyses results" stat report

--- a/src/bes/lims/adapters/configure.zcml
+++ b/src/bes/lims/adapters/configure.zcml
@@ -3,4 +3,10 @@
   <!-- Package includes -->
   <include package=".listing" />
 
+  <!-- IGetStickerTemplates adapter to only return the stickers from bes -->
+  <adapter
+      for="*"
+      provides="senaite.core.interfaces.IGetStickerTemplates"
+      factory=".stickers.StickerTemplates" />
+
 </configure>

--- a/src/bes/lims/adapters/stickers.py
+++ b/src/bes/lims/adapters/stickers.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of BES.LIMS.
+#
+# BES.LIMS is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2024-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from senaite.core.interfaces import IGetStickerTemplates
+from senaite.core.vocabularies.stickers import get_sticker_templates
+from zope.interface import implementer
+
+
+@implementer(IGetStickerTemplates)
+class StickerTemplates(object):
+    """
+    Adapter that returns a list of barcode stickers associated with products
+    that do not belong to senaite namespace. If the current instance does not
+    have barcode stickers registered other than those from senaite namespace,
+    the adapter returns all barcode sticker templates registered, regardless
+    of the namespace.
+
+    Each item in the returned list is a dict with the following structure:
+
+        {
+            "id": <template_id>,        # Unique identifier for the template
+            "title": <template_title>,  # Descriptive title of the template
+            "selected": True/False,     # False
+        }
+    """
+
+    def __init__(self, context):
+        self.context = context
+
+    def __call__(self, request):
+        """Returns the templates that do not belong to senaite namespace
+        """
+        # get all templates
+        templates = get_sticker_templates()
+
+        # purge those from senaite namespace
+        templates = filter(lambda tp: not self.is_from_senaite(tp), templates)
+
+        # skip auto-selection of template
+        for template in templates:
+            template["selected"] = False
+        return templates
+
+    def is_from_senaite(self, template):
+        """Returns whether this template is from senaite namespace
+        """
+        template_id = template.get("id")
+        if ":" not in template_id:
+            # ids from senaite.core come without prefix
+            return True
+        return template_id.startswith("senaite.")

--- a/src/bes/lims/patches/configure.zcml
+++ b/src/bes/lims/patches/configure.zcml
@@ -2,5 +2,6 @@
 
   <!-- Package includes -->
   <include package=".beka"/>
+  <include package=".vocabularies"/>
 
 </configure>

--- a/src/bes/lims/patches/vocabularies/__init__.py
+++ b/src/bes/lims/patches/vocabularies/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of BES.LIMS.
+#
+# BES.LIMS is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2024-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.

--- a/src/bes/lims/patches/vocabularies/configure.zcml
+++ b/src/bes/lims/patches/vocabularies/configure.zcml
@@ -1,0 +1,10 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:monkey="http://namespaces.plone.org/monkey">
+
+  <monkey:patch
+      class="senaite.core.vocabularies.stickers.StickerTemplatesVocabulary"
+      original="__call__"
+      replacement=".stickers.call" />
+
+</configure>

--- a/src/bes/lims/patches/vocabularies/stickers.py
+++ b/src/bes/lims/patches/vocabularies/stickers.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of BES.LIMS.
+#
+# BES.LIMS is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2024-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+
+from senaite.core.vocabularies.stickers import get_sticker_templates
+from senaite.core.schema.vocabulary import to_simple_vocabulary
+
+
+def call(self, context, filter_by_type=False):
+    templates = get_sticker_templates(filter_by_type=filter_by_type)
+
+    # purge templates from core (come without prefix followed by ':')
+    other = filter(lambda tp: ":" in tp.get("id"), templates)
+    core = filter(lambda tp: tp not in other, templates)
+
+    # if there are no product-specific templates, fallback to core's
+    templates = other if other else core
+
+    return to_simple_vocabulary([(t["id"], t["title"]) for t in templates])

--- a/src/bes/lims/profiles/default/metadata.xml
+++ b/src/bes/lims/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>1008</version>
+  <version>1009</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/bes/lims/upgrade/v01_00_000.zcml
+++ b/src/bes/lims/upgrade/v01_00_000.zcml
@@ -3,6 +3,14 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="Reset default sticker templates from setup"
+      description="Reset default sticker templates from setup"
+      source="1008"
+      destination="1009"
+      handler=".v01_00_000.reset_setup_sticker_templates"
+      profile="bes.lims:default"/>
+
+  <genericsetup:upgradeStep
       title="Setup product-specific roles and groups"
       description="Setup product-specific roles and groups"
       source="1007"


### PR DESCRIPTION
## Description

> [!WARNING]
> Requires:
> - https://github.com/senaite/senaite.core/pull/2692 

This Pull Request ensures stickers from senaite namespace are not displayed, but product-specific only.

## Current behavior

Sticker templates registered in senaite namespace are displayed

## Desired behavior

Sticker templates registered in senaite namespace are not displayed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
