### PR TITLE
Setup the Microbiology department for AST-like services and analyses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0
 -----
 
+- #47 Setup the Microbiology department for AST-like services and analyses
 - #32 Do not display stickers from senaite namespace
 - #31 Flat listing for default, due, received, to be verified and verified samples
 - #30 Add an "All" button to the department filter bar

--- a/src/bes/lims/profiles/default/metadata.xml
+++ b/src/bes/lims/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>1009</version>
+  <version>1010</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/bes/lims/upgrade/v01_00_000.py
+++ b/src/bes/lims/upgrade/v01_00_000.py
@@ -23,6 +23,7 @@ from bes.lims import PRODUCT_NAME as product
 from bes.lims.setuphandlers import setup_behaviors
 from bes.lims.setuphandlers import setup_catalogs
 from bes.lims.setuphandlers import setup_groups
+from bes.lims.setuphandlers import setup_microbiology_department
 from bes.lims.setuphandlers import setup_roles
 from bes.lims.setuphandlers import setup_workflows
 from bika.lims import api
@@ -37,6 +38,7 @@ from senaite.core.workflow import ANALYSIS_WORKFLOW
 from senaite.core.workflow import SAMPLE_WORKFLOW
 from zope import component
 from zope.schema.interfaces import IVocabularyFactory
+
 
 version = "1.0.0"  # Remember version number in metadata.xml and setup.py
 profile = "profile-{0}:default".format(product)
@@ -288,3 +290,15 @@ def reset_setup_sticker_templates(tool):
             continue
 
         field.set(setup, default)
+
+
+def setup_ast_department(tool):
+    """Setup the 'Microbiology' department for AST services and tests
+    """
+    logger.info("Setup department for AST services and analyses ...")
+    portal = tool.aq_inner.aq_parent
+
+    # setup microbiology department and assign the AST-like analyses to it
+    setup_microbiology_department(portal)
+
+    logger.info("Setup department for AST services and analyses [DONE]")

--- a/src/bes/lims/upgrade/v01_00_000.zcml
+++ b/src/bes/lims/upgrade/v01_00_000.zcml
@@ -3,6 +3,14 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="Setup the microbiology department for AST services and analyses"
+      description="Setup a department for AST services and tests"
+      source="1009"
+      destination="1010"
+      handler=".v01_00_000.setup_ast_department"
+      profile="bes.lims:default"/>
+
+  <genericsetup:upgradeStep
       title="Reset default sticker templates from setup"
       description="Reset default sticker templates from setup"
       source="1008"


### PR DESCRIPTION
## Description

This Pull Request assigns Microbiology as the default department for AST-like services and analyses.

Linked issue: #36

## Current behavior

AST-like services and analyses do not have a department assigned

## Desired behavior

AST-like services and analyses have a department assigned

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
