### PR TITLE
Display result interpretations from partitions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0
 -----
 
+- #48 Display result interpretations from partitions
 - #47 Setup the Microbiology department for AST-like services and analyses
 - #32 Do not display stickers from senaite namespace
 - #31 Flat listing for default, due, received, to be verified and verified samples

--- a/src/bes/lims/impress/reportview.py
+++ b/src/bes/lims/impress/reportview.py
@@ -556,10 +556,16 @@ class DefaultReportView(SingleReportView):
         return info
 
     def get_results_interpretations(self, model):
-        """Returns the result interpretations
+        """Returns the result interpretations, from partitions included
         """
-        # do a hard copy to prevent persistent changes
-        interpretations = copy.deepcopy(model.getResultsInterpretationDepts())
+        interpretations = []
+
+        # get from the partitions as well
+        samples = [model] + model.getDescendants(all_descendants=True)
+        for sample in samples:
+            # do a hard copy to prevent persistent changes
+            by_dept = sample.getResultsInterpretationDepts()
+            interpretations.extend(copy.deepcopy(by_dept))
 
         # group by user
         groups = collections.OrderedDict()


### PR DESCRIPTION
## Description

This Pull Request makes the result interpretation from partitions to be displayed in results report when publishing the primary sample.

Linked issue: #43 

## Current behavior

Result interpretations from partitions are not displayed when publishing the main sample

## Desired behavior

Result interpretations from partitions are not displayed when publishing the main sample

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
