### PR TITLE
Grant edit remarks permission for analyses in to_be_verified status

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0
 -----
 
+- #49 Grant edit remarks permission for analyses in to_be_verified status
 - #48 Display result interpretations from partitions
 - #47 Setup the Microbiology department for AST-like services and analyses
 - #32 Do not display stickers from senaite namespace

--- a/src/bes/lims/profiles/default/metadata.xml
+++ b/src/bes/lims/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>1010</version>
+  <version>1011</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/bes/lims/setuphandlers.py
+++ b/src/bes/lims/setuphandlers.py
@@ -33,6 +33,8 @@ from senaite.core.catalog import SETUP_CATALOG
 from senaite.core.setuphandlers import setup_core_catalogs
 from senaite.core.setuphandlers import setup_other_catalogs
 from senaite.core.workflow import ANALYSIS_WORKFLOW
+from senaite.core.workflow import DUPLICATE_ANALYSIS_WORKFLOW
+from senaite.core.workflow import REFERENCE_ANALYSIS_WORKFLOW
 from senaite.core.workflow import SAMPLE_WORKFLOW
 
 CATALOGS = (
@@ -84,6 +86,30 @@ GROUPS = [
 
 # Workflow updates
 WORKFLOWS_TO_UPDATE = {
+    DUPLICATE_ANALYSIS_WORKFLOW: {
+        "states": {
+            "to_be_verified": {
+                "permissions": {
+                    # allow LabManager, Manager and Scientist to edit remarks
+                    core_permissions.FieldEditAnalysisRemarks: [
+                        "Scientist", "LabManager", "Manager"
+                    ],
+                }
+            },
+        },
+    },
+    REFERENCE_ANALYSIS_WORKFLOW: {
+        "states": {
+            "to_be_verified": {
+                "permissions": {
+                    # allow LabManager, Manager and Scientist to edit remarks
+                    core_permissions.FieldEditAnalysisRemarks: [
+                        "Scientist", "LabManager", "Manager"
+                    ],
+                }
+            },
+        },
+    },
     ANALYSIS_WORKFLOW: {
         "states": {
             "assigned": {
@@ -129,7 +155,11 @@ WORKFLOWS_TO_UPDATE = {
             "to_be_verified": {
                 "permissions": {
                     # allow Scientist role to add analyses in to_be_verified
-                    core_permissions.AddAnalysis: ["Scientist", ]
+                    core_permissions.AddAnalysis: ["Scientist", ],
+                    # allow LabManager, Manager and Scientist to edit remarks
+                    core_permissions.FieldEditAnalysisRemarks: [
+                        "Scientist", "LabManager", "Manager"
+                    ],
                 }
             }
         }

--- a/src/bes/lims/upgrade/v01_00_000.zcml
+++ b/src/bes/lims/upgrade/v01_00_000.zcml
@@ -5,6 +5,14 @@
   <genericsetup:upgradeStep
       title="Setup the microbiology department for AST services and analyses"
       description="Setup a department for AST services and tests"
+      source="1010"
+      destination="1011"
+      handler=".v01_00_000.setup_edit_remarks"
+      profile="bes.lims:default"/>
+
+  <genericsetup:upgradeStep
+      title="Setup the microbiology department for AST services and analyses"
+      description="Setup a department for AST services and tests"
       source="1009"
       destination="1010"
       handler=".v01_00_000.setup_ast_department"


### PR DESCRIPTION
## Description

> [!WARNING]
> Requires:
> - https://github.com/senaite/senaite.core/pull/2733

This Pull Request grants the permission `Field: Edit Analysis Remarks` to roles `LabManager`, `Manager` and `Supervisor` for analyses in `to_be_verified` status.

Linked issue: #44 

## Current behavior

Unable to add test remark when in To be verified status

## Desired behavior

Able to add test remark when in To be verified status

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
