### PR TITLE
Allow to choose "out of stock" in analyses received by month stats report

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0
 -----
 
+- #54 Allow to choose "out of stock" in analyses received by month stats report
 - #49 Grant edit remarks permission for analyses in to_be_verified status
 - #48 Display result interpretations from partitions
 - #47 Setup the Microbiology department for AST-like services and analyses

--- a/src/bes/lims/reports/controls/analysis_states.pt
+++ b/src/bes/lims/reports/controls/analysis_states.pt
@@ -1,0 +1,18 @@
+<tal:control i18n:domain="bes.lims"
+  define="default python:['to_be_verified', 'verified', 'published']">
+
+  <!-- Analysis statuses -->
+  <label for="analysis_states" class="field mr-2" i18n:translate="">
+    Analysis states
+    </label>
+  <select name="analysis_states"
+          class="form-control form-control-sm mr-2" multiple>
+    <tal:options repeat="state_info python:view.get_analysis_states()">
+      <option tal:attributes="value python:state_info[0];
+                              selected python:'selected' if state_info[0] in default else None"
+              tal:content="python: state_info[1]">
+      </option>
+    </tal:options>
+  </select>
+
+</tal:control>

--- a/src/bes/lims/reports/controls/department.pt
+++ b/src/bes/lims/reports/controls/department.pt
@@ -3,6 +3,7 @@
   <!-- Department -->
   <label for="year" class="field mr-2" i18n:translate="">Department</label>
   <select name="department" class="form-control form-control-sm mr-2">
+    <option value='__all__' i18n:translate="">All departments</option>
     <option value="" i18n:translate="">Without department assigned</option>
     <tal:options repeat="department python:view.get_departments()">
       <option tal:attributes="value department/uid"

--- a/src/bes/lims/reports/forms/analyses_lab_departments_by_month.py
+++ b/src/bes/lims/reports/forms/analyses_lab_departments_by_month.py
@@ -42,9 +42,12 @@ class AnalysesLabDepartmentsByMonth(CSVReport):
         year = int(self.request.form.get("year"))
         # search by requested department
         department_uid = self.request.form.get("department")
-        brains = get_analyses_by_year(year, review_state=statuses,
-                                      department_uid=department_uid,
-                                      getPointOfCapture=poc)
+        query = {"review_state": statuses, "getPointOfCapture": poc}
+        if api.is_uid(department_uid):
+            query["department_uid"] = department_uid
+
+        # do the search
+        brains = get_analyses_by_year(year, **query)
 
         # add the first two rows (header)
         department = api.get_object_by_uid(department_uid, default=None)

--- a/src/bes/lims/reports/forms/analyses_lab_departments_by_month.py
+++ b/src/bes/lims/reports/forms/analyses_lab_departments_by_month.py
@@ -34,8 +34,8 @@ class AnalysesLabDepartmentsByMonth(CSVReport):
     """
 
     def process_form(self):
-        # verified and published samples that were received within a given year
-        statuses = ["to_be_verified", "verified", "published"]
+        # analysis states
+        statuses = self.request.form.get("analysis_states")
         # skip AST-like analyses
         poc = ["lab", "field"]
         # search by requested year

--- a/src/bes/lims/reports/forms/analyses_results.py
+++ b/src/bes/lims/reports/forms/analyses_results.py
@@ -43,8 +43,12 @@ class AnalysesResults(CSVReport):
 
         # search by requested department
         department_uid = self.request.form.get("department")
-        brains = get_analyses(date_from, date_to, review_state=statuses,
-                              department_uid=department_uid)
+        query = {"review_state": statuses}
+        if api.is_uid(department_uid):
+            query["department_uid"] = department_uid
+
+        # do the search
+        brains = get_analyses(date_from, date_to, **query)
         objs = map(api.get_object, brains)
         analyses = [analysis for analysis in objs if is_reportable(analysis)]
 

--- a/src/bes/lims/reports/reportview.py
+++ b/src/bes/lims/reports/reportview.py
@@ -29,11 +29,14 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile as PT
 from senaite.app.supermodel import SuperModel
 from senaite.core.catalog import SAMPLE_CATALOG
 from senaite.core.catalog import SETUP_CATALOG
+from senaite.core.workflow import ANALYSIS_WORKFLOW
+from senaite.core.api import workflow as wapi
 
 YEAR_CONTROL = "controls/year.pt"
 DATE_CONTROL = "controls/date.pt"
 TARGET_PATIENT_CONTROL = "controls/target_patient.pt"
 DEPARTMENT_CONTROL = "controls/department.pt"
+ANALYSIS_STATES_CONTROL = "controls/analysis_states.pt"
 
 
 class StatisticReportsView(BrowserView):
@@ -73,6 +76,11 @@ class StatisticReportsView(BrowserView):
         """
         return PT(DEPARTMENT_CONTROL)(self)
 
+    def analysis_states_control(self):
+        """Returns the control for the selection of analysis states
+        """
+        return PT(ANALYSIS_STATES_CONTROL)(self)
+
     @view.memoize
     def get_years(self):
         """Returns the list of years since the first sample was created
@@ -103,6 +111,17 @@ class StatisticReportsView(BrowserView):
         }
         brains = api.search(query, SETUP_CATALOG)
         return [SuperModel(brain) for brain in brains]
+
+    @view.memoize
+    def get_analysis_states(self):
+        """Returns the list of analysis statuses that are suitable for
+        reporting, as tuples of (state_id, state_title): verified,
+        to_be_verified, published and out_of_stock
+        """
+        supported = ["to_be_verified", "verified", "published", "out_of_stock"]
+        wf = wapi.get_workflow(ANALYSIS_WORKFLOW)
+        return [(state, wf.getTitleForStateOnType(state, "Analysis"))
+                for state in supported]
 
     def get_target_patients(self):
         """Returns the list target patient

--- a/src/bes/lims/reports/templates/analyses_lab_departments_by_month.pt
+++ b/src/bes/lims/reports/templates/analyses_lab_departments_by_month.pt
@@ -9,8 +9,7 @@
 
     <p i18n:translate="">
       Number of analyses for a given department from samples received within a
-      year, grouped by month. Only analyses in any of the following statuses
-      are considered: 'To be verified', 'Verified' or 'Published'
+      year, grouped by month.
     </p>
 
     <div class="form-group form-inline">
@@ -20,6 +19,9 @@
 
       <!-- Department control -->
       <tal:department replace="structure python:view.department_control()"/>
+
+      <!-- Analysis states -->
+      <tal:states replace="structure python:view.analysis_states_control()"/>
 
     </div>
 


### PR DESCRIPTION
## Description

This Pull Requests adds the following:

- An option "All departments" for department selector control
- A multiselector of analysis statuses in recieved by month stats report

Linked issue: #11 

## Current behavior

Is not possible to get the analyses that were transitioned to "out of stock"

## Desired behavior

Is possible to get the analyses that were transitioned to "out of stock"

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
