### PR TITLE
Fix microorganism identification analysis not being added

### DIFF
--- a/src/bes/lims/configure.zcml
+++ b/src/bes/lims/configure.zcml
@@ -26,6 +26,7 @@
   <include package=".extender"/>
   <include package=".impress"/>
   <include package=".patches"/>
+  <include package=".reflex"/>
   <include package=".reports"/>
   <include package=".subscribers"/>
   <include package=".upgrade"/>

--- a/src/bes/lims/reflex/__init__.py
+++ b/src/bes/lims/reflex/__init__.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+from zope.component import queryAdapter
+from zope.interface import Interface
+from zope.interface import implements
+
+
+class IReflexTesting(Interface):
+    """Marker interface for Reflex Testing Adapters
+    """
+
+    def __call__(self):
+        """Executes the reflex testing for the analysis
+        """
+
+
+class ReflexTestingBaseAdapter(object):
+    """Base Reflex Testing Adapter
+    """
+    implements(IReflexTesting)
+
+    def __init__(self, analysis):
+        self.analysis = analysis
+
+
+def get_reflex_testing_adapter(analysis, action):
+    """Returns a reflex testing adapter for this analysis, if any
+    """
+    keyword = analysis.getKeyword()
+
+    # Replace special characters from the keyword
+    keyword = keyword.replace("-", "")
+    keyword = keyword.lower()
+
+    # Run CINTER's reflex testing when keyword *starts* with CINTER
+    # https://github.com/beyondessential/pnghealth.lims/issues/127
+    if keyword.startswith("cinter"):
+        keyword = "cinter"
+
+    name = "bes.lims.reflex.{}.{}".format(keyword, action)
+    return queryAdapter(analysis, IReflexTesting, name=name)

--- a/src/bes/lims/reflex/cinter.py
+++ b/src/bes/lims/reflex/cinter.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+
+import json
+
+from bes.lims import logger
+from bes.lims.reflex import ReflexTestingBaseAdapter
+from bes.lims.reflex import utils
+from bika.lims.utils.analysis import create_analysis
+from senaite.ast.config import IDENTIFICATION_KEY
+
+
+class CultureInterpretationSubmitAdapter(ReflexTestingBaseAdapter):
+    """Adapter in charge of adding the Organisms analysis if the result
+    of the culture interpretation is positive
+    """
+
+    def __call__(self):
+        if not self.is_positive():
+            # No growth/Negative, do nothing
+            return
+
+        sibling = self.get_siblings(IDENTIFICATION_KEY)
+        if sibling:
+            # The sample current analysis belongs to already has an Organism
+            # Identification analysis set
+            return
+
+        # Create a new Organism test
+        self.create_organism_identification()
+
+    def get_siblings(self, keyword):
+        """Returns the analysis siblings for the given keyword, that belong to
+        the same sample as the current analysis
+        """
+        sample = self.analysis.getRequest()
+        analyses = sample.getAnalyses(full_objects=True)
+        return filter(lambda an: an.getKeyword() == keyword, analyses)
+
+    def is_positive(self):
+        """Returns whether there is culture growth based on the result of the
+        Culture Interpretation test
+        """
+        options = self.analysis.getResultOptions()
+        if not options:
+            return False
+
+        values = map(lambda opt: str(opt.get("ResultValue", "")), options)
+        texts = map(lambda opt: opt.get("ResultText", ""), options)
+        flags = map(lambda opt: opt.get("Flag", ""), options)
+        values_texts = dict(zip(values, texts))
+        values_flags = dict(zip(values, flags))
+
+        # Result might contain a single result option
+        result = self.analysis.getResult()
+        text_value = values_texts.get(str(result))
+        if text_value:
+            return values_flags.get(str(result)) == "positive"
+
+        # Result might be a string with multiple options e.g. "['2', '1']"
+        try:
+            raw_result = json.loads(result)
+            for result in raw_result:
+                text_value = values_texts.get(str(result))
+                if text_value:
+                    flag = values_flags.get(str(result))
+                    if flag == "positive":
+                        return True
+        except (ValueError, TypeError):
+            pass
+
+        return False
+
+    def create_organism_identification(self):
+        """Creates a new Microorganism identification test (senaite.ast) in the
+        same samples as the current analysis. The result options of the new
+        test are populated with the list (names) of the organisms that are
+        available in the system and the control input is set to "multiselect".
+        """
+        keyword = IDENTIFICATION_KEY
+        service = utils.get_service(keyword)
+        if not service:
+            logger.error("Service '{}' is missing".format(keyword))
+
+        # Make some room for the new identifier
+        sample = self.analysis.getRequest()
+        new_id = utils.new_analysis_id(sample, keyword)
+
+        # Create the analysis
+        new_test = create_analysis(sample, service, id=new_id)
+        new_test.setResult("")
+        new_test.setResultCaptureDate(None)
+
+        # On occasions the gram stain may be positive (eg Gram negative rods)
+        # but nothing will grow. Accommodate "No culture growth obtained"
+        no_growth = "No culture growth obtained"
+
+        # Get the organisms vocabulary
+        organisms = utils.get_organisms_vocabulary(empty=no_growth)
+
+        # Create and assign the result options
+        values_organisms = zip(range(len(organisms)), organisms)
+        options = map(self.to_result_option, values_organisms)
+        new_test.setResultOptions(options)
+        new_test.setResultOptionsType("multiselect")
+        new_test.reindexObject()
+        return new_test
+
+    def to_result_option(self, value_organism):
+        """Converts a tuple of (index, organism_name) to a ResultOption entry
+        suitable for Analysis, in which the first element of the tuple is the
+        ResultValue and the second is the text to be displayed in widgets
+        :param value_organism: tuple of (result value, result text)
+        :return: dict {"ResultValue": <value>, "ResultText": <text>}
+        """
+        return {
+            "ResultValue": value_organism[0],
+            "ResultText": value_organism[1]
+        }

--- a/src/bes/lims/reflex/configure.zcml
+++ b/src/bes/lims/reflex/configure.zcml
@@ -1,0 +1,10 @@
+<configure
+  xmlns="http://namespaces.zope.org/zope">
+
+  <!-- Culture interpretation -->
+  <adapter
+    name="bes.lims.reflex.cinter.submit"
+    factory=".cinter.CultureInterpretationSubmitAdapter"
+    for="bika.lims.interfaces.analysis.IRequestAnalysis" />
+
+</configure>

--- a/src/bes/lims/reflex/utils.py
+++ b/src/bes/lims/reflex/utils.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+from bika.lims import api
+from senaite.core.catalog import SETUP_CATALOG
+
+
+def get_service(keyword):
+    """Returns the Analysis Service for the given keyword, if any
+    """
+    service = None
+    query = {
+        "portal_type": "AnalysisService",
+        "getKeyword": keyword
+    }
+    brains = api.search(query, SETUP_CATALOG)
+    if len(brains) == 1:
+        service = api.get_object(brains[0])
+    return service
+
+
+def new_analysis_id(sample, analysis_keyword):
+    """Returns a new analysis id for an hypothetic new test with given keyword
+    to prevent clashes with ids of other analyses from same sample
+    """
+    new_id = analysis_keyword
+    analyses = sample.getAnalyses(getKeyword=analysis_keyword)
+    if analyses:
+        new_id = "{}-{}".format(analysis_keyword, len(analyses))
+    return new_id
+
+
+def get_organisms_vocabulary(empty=None, **kwargs):
+    """Returns a vocabulary of organisms items based on the search criteria
+    passed-in. By default, if not kwargs are specified, returns the list of
+    active Microorganisms sorted by title, ascending
+    :param empty: text for the empty option to be returned in first place. If
+        the value of empty is None, does not add an empty option
+    """
+    query = {
+        "is_active": True,
+        "sort_on": "sortable_title",
+        "sort_order": "ascending"
+    }
+    query.update(kwargs)
+    query["portal_type"] = "Microorganism"
+
+    # Search the organisms and build the list of options
+    organisms = map(api.get_title, api.search(query, SETUP_CATALOG))
+
+    # Insert the empty value, if any
+    if empty is not None:
+        organisms.insert(0, empty)
+
+    return organisms

--- a/src/bes/lims/workflow/analysis/events.py
+++ b/src/bes/lims/workflow/analysis/events.py
@@ -18,14 +18,33 @@
 # Copyright 2024-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from DateTime import DateTime
+from bes.lims.reflex import get_reflex_testing_adapter
 from bes.lims.utils import get_previous_status
 from bika.lims import api
 from bika.lims.interfaces import ISubmitted
 from bika.lims.interfaces import IVerified
 from bika.lims.workflow import doActionFor
-from DateTime import DateTime
 from senaite.core.workflow import ANALYSIS_WORKFLOW
 from zope.interface import alsoProvides
+
+
+def after_submit(analysis):
+    """Event fired when an analysis result gets submitted
+    """
+    # Handle reflex testing if necessary
+    adapter = get_reflex_testing_adapter(analysis, "submit")
+    if adapter:
+        adapter()
+
+
+def after_verify(analysis):
+    """Event fired when an analysis result gets submitted
+    """
+    # Handle reflex testing if necessary
+    adapter = get_reflex_testing_adapter(analysis, "verify")
+    if adapter:
+        adapter()
 
 
 def after_set_out_of_stock(analysis):


### PR DESCRIPTION
## Description

This Pull Request ensures that when a positive result for Culture interpretation-*like* tests is submitted, the full view is reloaded in accordance so the test Microorganism Identification becomes visible for data entry.

Linked issue: #53 

## Current behavior

The Microorganism Identification is not visible after submitting a positive result for "Culture Interpretation"-like test

## Desired behavior

The Microorganism Identification is visible after submitting a positive result for "Culture Interpretation"-like test

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
