### PR TITLE
Merge PDF attachments into results report on publish

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0
 -----
 
+- #65 Add methods to retrieve and merge PDF attachments into published report
 - #61 Enhance analysis results statistic report
 - #60 Port Tamanu integration scripts and logic from palau.lims
 - #57 Hide analysis conditions not flagged with "Show in report"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 1.0.0
 -----
 
-- #65 Add methods to retrieve and merge PDF attachments into published report
+- #65 Merge PDF attachments into results report on publish
 - #61 Enhance analysis results statistic report
 - #60 Port Tamanu integration scripts and logic from palau.lims
 - #57 Hide analysis conditions not flagged with "Show in report"

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,8 @@ setup(
         # senaite.core does no longer provides schemaextender
         # https://github.com/senaite/senaite.core/pull/1931
         "archetypes.schemaextender",
+        # Version 2.0 does no longer support python 2.7
+        "PyPDF2==1.28.5",
         # Python 2.7: python-slugify < 5.0.0
         # Python 3.6+: python-slugify >= 5.0.0
         "python-slugify < 5.0.0",

--- a/src/bes/lims/adapters/configure.zcml
+++ b/src/bes/lims/adapters/configure.zcml
@@ -9,4 +9,12 @@
       provides="senaite.core.interfaces.IGetStickerTemplates"
       factory=".stickers.StickerTemplates" />
 
+
+  <!-- PDF Report Storage Adapter -->
+  <adapter
+      for="zope.interface.Interface
+           bes.lims.interfaces.IBESLimsLayer"
+      factory=".impress.PdfReportStorageAdapter"
+      permission="zope2.View"/>
+
 </configure>

--- a/src/bes/lims/adapters/impress.py
+++ b/src/bes/lims/adapters/impress.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of BES.LIMS.
+#
+# BES.LIMS is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2024-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+import transaction
+from bes.lims import logger
+from bika.lims import api
+from senaite.impress.decorators import synchronized
+from senaite.impress.storage import PdfReportStorageAdapter as BaseAdapter
+from bika.lims.workflow import doActionFor as do_action_for
+from PyPDF2 import PdfMerger
+from StringIO import StringIO
+
+
+class PdfReportStorageAdapter(BaseAdapter):
+    """Storage adapter for PDF reports with PDF attachment support
+    """
+
+    def get_pdf_attachments(self, parent):
+        """Get PDF attachments that are flagged for rendering in report
+        """
+        pdf_attachments = []
+
+        # Get sample attachments
+        attachments = parent.getAttachment()
+
+        for attachment in attachments:
+            if not attachment.getRenderInReport():
+                continue
+
+            attachment_file = attachment.getAttachmentFile()
+            if not attachment_file:
+                continue
+
+            # Check if it's a PDF
+            content_type = attachment_file.getContentType()
+            if content_type and content_type.lower() == 'application/pdf':
+                pdf_attachments.append(attachment)
+
+        return pdf_attachments
+
+    def merge_pdf_attachments(self, main_pdf, attachments):
+        """Merge PDF attachments into the main PDF
+        """
+        if not attachments:
+            return main_pdf
+
+        # Create PDF merger
+        merger = PdfMerger()
+
+        main_pdf_stream = StringIO(main_pdf)
+        merger.append(main_pdf_stream)
+
+        # Add each PDF attachment
+        for attachment in attachments:
+            attachment_file = attachment.getAttachmentFile()
+            attachment_data = attachment_file.data
+            attachment_stream = StringIO(attachment_data)
+            merger.append(attachment_stream)
+
+        output = StringIO()
+        merger.write(output)
+        merged_pdf = output.getvalue()
+        output.close()
+        merger.close()
+
+        return merged_pdf
+
+    @synchronized(max_connections=1)
+    def create_report(self, parent, pdf, html, uids, metadata):
+        """Create a new report object
+
+        NOTE: We limit the creation of reports to 1 to avoid conflict errors on
+              simultaneous publication.
+
+        :param parent: parent object where to create the report inside
+        :returns: ARReport
+        """
+
+        parent_id = api.get_id(parent)
+        logger.info("Create Report for {} ...".format(parent_id))
+
+        # Manually update the view on the database to avoid conflict errors
+        parent._p_jar.sync()
+
+        # Get PDF attachments that should be merged
+        pdf_attachments = self.get_pdf_attachments(parent)
+
+        # Merge PDF attachments into the main PDF if any exist
+        if pdf_attachments:
+            pdf = self.merge_pdf_attachments(pdf, pdf_attachments)
+
+        # Create the report object
+        report = api.create(
+            parent,
+            "ARReport",
+            AnalysisRequest=api.get_uid(parent),
+            Pdf=pdf,
+            Html=html,
+            ContainedAnalysisRequests=uids,
+            Metadata=metadata)
+
+        # Transition the sample to published status
+        do_action_for(parent, "publish")
+
+        # Commit the changes
+        transaction.commit()
+
+        logger.info("Create Report for {} [DONE]".format(parent_id))
+
+        return report


### PR DESCRIPTION
## Description
This PR enables merging of PDF attachments flagged with "Render in report" into the final published report.

Linked issue: https://github.com/beyondessential/bes.lims/issues/14

## Current behavior
When an attachment is added to a sample and "Render in report" is selected, the attachment does not appear in the generated report

## Desired behavior
When a sample has an attachment and "Render in report" is selected, the attachment should be displayed in the report

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
