### PR TITLE
Add watermark for invalid reports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0
 -----
 
+- #66 Add watermark for invalid reports
 - #65 Merge PDF attachments into results report on publish
 - #61 Enhance analysis results statistic report
 - #60 Port Tamanu integration scripts and logic from palau.lims

--- a/src/bes/lims/adapters/impress.py
+++ b/src/bes/lims/adapters/impress.py
@@ -18,6 +18,8 @@
 # Copyright 2024-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from bika.lims.utils import createPdf
 import transaction
 from bes.lims import logger
 from bika.lims import api
@@ -25,12 +27,15 @@ from senaite.impress.decorators import synchronized
 from senaite.impress.storage import PdfReportStorageAdapter as BaseAdapter
 from bika.lims.workflow import doActionFor as do_action_for
 from PyPDF2 import PdfMerger
+from PyPDF2 import PdfReader
+from PyPDF2 import PdfWriter
 from StringIO import StringIO
 
 
 class PdfReportStorageAdapter(BaseAdapter):
     """Storage adapter for PDF reports with PDF attachment support
     """
+    template = ViewPageTemplateFile("templates/watermark.pt")
 
     def get_pdf_attachments(self, parent):
         """Get PDF attachments that are flagged for rendering in report
@@ -82,6 +87,37 @@ class PdfReportStorageAdapter(BaseAdapter):
 
         return merged_pdf
 
+    def apply_watermark(self, input_pdf, watermark_pdf):
+        """Apply watermark to PDF data
+        """
+        # Read the PDF
+        pdf_reader = PdfReader(StringIO(input_pdf))
+        writer = PdfWriter()
+
+        # watermark_pdf_stream = StringIO(watermark_pdf_data)
+        watermark_pdf_reader = PdfReader(StringIO(watermark_pdf))
+        watermark_page = watermark_pdf_reader.pages[0]
+
+        # Process each page
+        for page_num in range(pdf_reader.getNumPages()):
+            pdf_page = pdf_reader.pages[page_num]
+            pdf_page.merge_page(watermark_page)
+            writer.add_page(pdf_page)
+
+        # Write the watermarked PDF
+        output = StringIO()
+        writer.write(output)
+        pdf = output.getvalue()
+        output.close()
+
+        return pdf
+
+    def create_watermark_pdf(self, text):
+        """Create watermark PDF data with embedded text
+        """
+        watermark_pdf = createPdf(self.template(text=text))
+        return watermark_pdf
+
     @synchronized(max_connections=1)
     def create_report(self, parent, pdf, html, uids, metadata):
         """Create a new report object
@@ -105,6 +141,11 @@ class PdfReportStorageAdapter(BaseAdapter):
         # Merge PDF attachments into the main PDF if any exist
         if pdf_attachments:
             pdf = self.merge_pdf_attachments(pdf, pdf_attachments)
+
+        # Apply watermark if sample is invalid
+        if api.get_review_status(parent) == "invalid":
+            watermark_pdf = self.create_watermark_pdf("INVALID")
+            pdf = self.apply_watermark(pdf, watermark_pdf)
 
         # Create the report object
         report = api.create(

--- a/src/bes/lims/adapters/templates/watermark.pt
+++ b/src/bes/lims/adapters/templates/watermark.pt
@@ -1,0 +1,38 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      i18n:domain="bes.lims">
+  <body>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100vh;
+        font-family: Arial, sans-serif;
+        background: transparent;
+      }
+      .watermark {
+        font-size: 48px;
+        font-weight: bold;
+        color: #888;
+        opacity: 0.12;
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%) rotate(-30deg);
+        white-space: nowrap;
+        z-index: 1000;
+        text-shadow: 2px 2px 8px #fff, 2px 2px 4px #000;
+        letter-spacing: 8px;
+        width: 120vw;
+        text-align: center;
+        pointer-events: none;
+      }
+    </style>
+    <div class="watermark">
+      <span class="watermark-text" tal:content="options/text"></span>
+    </div>
+  </body>
+</html>

--- a/src/bes/lims/profiles/default/metadata.xml
+++ b/src/bes/lims/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>1012</version>
+  <version>1013</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/bes/lims/setuphandlers.py
+++ b/src/bes/lims/setuphandlers.py
@@ -161,7 +161,15 @@ WORKFLOWS_TO_UPDATE = {
                         "Scientist", "LabManager", "Manager"
                     ],
                 }
-            }
+            },
+            "invalid": {
+                "transitions": ["republish"],
+                "permissions": {
+                    core_permissions.TransitionPublishResults: (
+                        "LabManager", "Manager"
+                    ),
+                }
+            },
         }
     }
 }

--- a/src/bes/lims/upgrade/v01_00_000.py
+++ b/src/bes/lims/upgrade/v01_00_000.py
@@ -355,3 +355,30 @@ def setup_tamanu_catalogs(tool):
     portal = tool.aq_inner.aq_parent
     setup_catalogs(portal)
     logger.info("Setup Tamanu integration [DONE]")
+
+
+def add_republish_transition_to_invalidate_state(tool):
+    """Adds the `republish` transition to the
+    `invalidated` state in the sample workflow
+    """
+    logger.info("Add `republish` transition to `invalidate` state ...")
+    portal = tool.aq_inner.aq_parent
+
+    # Update workflows
+    setup_workflows(portal)
+
+    # Update role mappings for existing samples in invalid status
+    query = {
+        "portal_type": "AnalysisRequest",
+        "review_state": "invalid"
+    }
+    wf = wapi.get_workflow(SAMPLE_WORKFLOW)
+    brains = api.search(query, SAMPLE_CATALOG)
+    for brain in brains:
+        sample = get_object(brain)
+        if not sample:
+            continue
+        wf.updateRoleMappingsFor(sample)
+        sample._p_deactivate()
+
+    logger.info("Add `republish` transition to `invalidate` state [DONE]")

--- a/src/bes/lims/upgrade/v01_00_000.zcml
+++ b/src/bes/lims/upgrade/v01_00_000.zcml
@@ -3,6 +3,14 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="Add `republish` transition to `invalidate` state"
+      description="Add `republish` transition to `invalidate` state"
+      source="1012"
+      destination="1013"
+      handler=".v01_00_000.add_republish_transition_to_invalidate_state"
+      profile="bes.lims:default"/>
+
+  <genericsetup:upgradeStep
       title="Setup catalogs for integration with Tamanu"
       description="Setup new catalogs and/or modify existing ones for the
         integration with Tamanu to work properly"


### PR DESCRIPTION
## Description
This Pull request helps to add watermark for invalid reports

Linked issue: https://github.com/beyondessential/bes.lims/issues/63

## Current behavior
- The invalid sample cannot be published
- Invalid reports do not have a watermark

## Desired behavior
- The Invalid sample can be published
- Invalid reports have a watermark


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
