### PR TITLE
Exclude out-of-stock analyses from provisional status check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0
 -----
 
+- 69 Exclude out-of-stock analyses from provisional status check
 - #67 Import ward location from Tamanu's ServiceRequest
 - #66 Add watermark for invalid reports
 - #65 Merge PDF attachments into results report on publish

--- a/src/bes/lims/impress/reportview.py
+++ b/src/bes/lims/impress/reportview.py
@@ -622,3 +622,26 @@ class DefaultReportView(SingleReportView):
         """Returns whether the analysis passed-in is out-of-stock
         """
         return api.get_review_status(analysis) == "out_of_stock"
+
+    def is_valid_status(self, analysis):
+        """Returns whether the analysis object or brain is in a valid status
+        """
+        invalid = ["retracted", "rejected", "cancelled"]
+        return api.get_review_status(analysis) not in invalid
+
+    def is_results_in_progress(self, sample):
+        """Returns true if there are analyses not yet verified
+        """
+        def in_progress(analysis):
+            return (
+                not analysis.getDateVerified()
+                and not self.is_out_of_stock(analysis)
+            )
+
+        # Exclude invalid analyses
+        analyses = self.get_analyses(sample)
+        analyses = filter(self.is_valid_status, analyses)
+
+        # Ensure all valid analyses are in progress
+        analyses = map(in_progress, analyses)
+        return any(analyses)

--- a/src/bes/lims/impress/reportview.py
+++ b/src/bes/lims/impress/reportview.py
@@ -633,10 +633,14 @@ class DefaultReportView(SingleReportView):
         """Returns true if there are analyses not yet verified
         """
         def in_progress(analysis):
-            return (
-                not analysis.getDateVerified()
-                and not self.is_out_of_stock(analysis)
-            )
+            if analysis.getDateVerified():
+                return False
+            if self.is_out_of_stock(analysis):
+                # do not display results as provisional for analyses that are
+                # in the out-of-stock analysis
+                # https://github.com/beyondessential/bes.lims/pull/69
+                return False
+            return True
 
         # Exclude invalid analyses
         analyses = self.get_analyses(sample)


### PR DESCRIPTION
## Description
This PR updates the logic used to determine if a sample has results "in progress" by correctly excluding analyses that are marked as out of stock. Since the out-of-stock status is final, these analyses should not trigger the display of a provisional comment on the final report

Linked issue: https://github.com/beyondessential/bes.lims/issues/28

## Current behavior
When a sample is transitioned to an "out of stock" status (which is final), it is still incorrectly considered as "provisional." As a result, the "provisional results" comment appears on the final report, even though no further results are expected.

## Desired behavior
Samples with only "out of stock" analyses should not be marked as provisional, and the "provisional results" comment should not appear on the final report. The red dot may remain for visibility, but it should not affect the final status or display provisional messaging.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
