### PR TITLE
Fix 'getDepartmentTitle' AttributeError on statistics report creation

### DIFF
--- a/src/bes/lims/reports/forms/analyses_results.py
+++ b/src/bes/lims/reports/forms/analyses_results.py
@@ -90,7 +90,10 @@ class AnalysesResults(CSVReport):
                 result = analysis.getFormattedResult(html=False) or result
                 result = self.replace_html_breaklines(result)
 
-            department = analysis.getDepartmentTitle() or ""
+            # get the department title
+            department = analysis.getDepartment()
+            department = api.get_title(department) if department else ""
+
             profiles = self.get_analysis_profiles(sample)
             unit = format_supsub(to_utf8(analysis.Unit))
 


### PR DESCRIPTION
## Description

This Pull Request fixes an `AttributeError` when generating Analysis statistic results report.

## Current behavior

```
2025-08-04 11:48:47,883 ERROR   [Zope.SiteErrorLog:252][waitress-0] 1754300927.880.242291798653 http://localhost:9090/senaite/statistic_reports
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module bes.lims.reports.reportview, line 55, in __call__
  Module bes.lims.reports.forms, line 39, in __call__
  Module bes.lims.reports.forms.analyses_results, line 93, in process_form
AttributeError: 'RequestContainer' object has no attribute 'getDepartmentTitle
```

## Desired behavior

No error, the statistics report as a `CSV` file is properly generated

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
