### PR TITLE
Disable title-based matching when importing analyses from Tamanu

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0
 -----
 
+- #73 Disable title-based matching when importing analyses from Tamanu
 - #72 Make statistic report of analyses results more reusable
 - #71 Fix 'getDepartmentTitle' AttributeError on statistics report creation
 - #69 Exclude out-of-stock analyses from provisional status check

--- a/scripts/sync_tamanu.py
+++ b/scripts/sync_tamanu.py
@@ -344,12 +344,10 @@ def get_services(service_request):
     services = []
 
     # get all services and group them by title
-    by_title = {}
     by_keyword = {}
     sc = api.get_tool(SETUP_CATALOG)
     for brain in sc(portal_type="AnalysisService"):
         obj = api.get_object(brain)
-        by_title[api.get_title(obj)] = obj
         by_keyword[obj.getKeyword()] = obj
 
     # get the codes requested in the ServiceRequest
@@ -357,13 +355,7 @@ def get_services(service_request):
     for coding in tapi.get_codings(details, SENAITE_TESTS_CODING_SYSTEM):
         # get the analysis by keyword
         code = coding.get("code")
-        service = by_keyword.get(code)
-        if not service:
-            # fallback to title
-            # TODO Fallback searches by analysis to CommercialName instead?
-            display = coding.get("display")
-            service = by_title.get(display)
-
+        service = by_keyword.pop(code, None)
         if service:
             services.append(service)
 


### PR DESCRIPTION
## Description

This Pull Request disables the title-based matching when importing analyses from Tamanu

Linked issue: #70 

## Current behavior

System uses both `Keyword` and `title` to identify matches with analysis services.

## Desired behavior

System uses only `Keyword` to identify matches with analysis services.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
