### PR TITLE
Add date range search function in samples listing

### DIFF
--- a/src/bes/lims/browser/configure.zcml
+++ b/src/bes/lims/browser/configure.zcml
@@ -5,6 +5,7 @@
 
   <!-- Package includes -->
   <include package=".controlpanel"/>
+  <include package=".daterangefilter"/>
   <include package=".departmentfilter"/>
   <include package=".sample"/>
   <include package=".sampletype"/>

--- a/src/bes/lims/browser/daterangefilter/__init__.py
+++ b/src/bes/lims/browser/daterangefilter/__init__.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of BES.LIMS.
+#
+# BES.LIMS is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2024-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from datetime import datetime
+from zope.globalrequest import getRequest
+
+# Session storage key
+SESSION_KEY = "daterangefilter.storage"
+
+
+def get_selected_date_range():
+    """Returns the date range (from, to, type) currently selected.
+
+    If no date range was explicitly selected in the UI, the
+    function defaults to returning the current month range.
+    """
+    request = getRequest()
+    if request and hasattr(request, 'SESSION'):
+        session_data = request.SESSION.get(SESSION_KEY)
+        if session_data:
+            return session_data
+
+    # Default to current month and created date type
+    now = datetime.now()
+    first_day = datetime(now.year, now.month, 1)
+    datetime_from = first_day.strftime("%Y-%m-%d 00:00")
+    datetime_to = now.strftime("%Y-%m-%d 23:59")
+
+    return {
+        "datetime_from": datetime_from,
+        "datetime_to": datetime_to,
+        "date_type": "created"
+    }
+
+
+def set_selected_date_range(datetime_from, datetime_to, date_type):
+    """Sets the datetime range and type in session storage"""
+    request = getRequest()
+    if request and hasattr(request, 'SESSION'):
+        request.SESSION[SESSION_KEY] = {
+            "datetime_from": datetime_from,
+            "datetime_to": datetime_to,
+            "date_type": date_type
+        }

--- a/src/bes/lims/browser/daterangefilter/configure.zcml
+++ b/src/bes/lims/browser/daterangefilter/configure.zcml
@@ -1,0 +1,20 @@
+<configure xmlns="http://namespaces.zope.org/zope"
+           xmlns:browser="http://namespaces.zope.org/browser">
+
+  <!-- Date Range filtering viewlet -->
+  <browser:viewlet
+      for="bika.lims.interfaces.IAnalysisRequestsFolder"
+      name="bes.lims.viewlet.daterangefilter"
+      class=".viewlet.DateRangeFilteringViewlet"
+      manager="plone.app.layout.viewlets.interfaces.IBelowContentTitle"
+      permission="zope2.View"
+      layer="bes.lims.interfaces.IBESLimsLayer" />
+
+  <!-- Samples listing -->
+  <subscriber
+      for="bika.lims.browser.analysisrequest.AnalysisRequestsView
+           *"
+      provides="senaite.app.listing.interfaces.IListingViewAdapter"
+      factory=".listing.DateRangeFilterListingAdapter" />
+
+</configure>

--- a/src/bes/lims/browser/daterangefilter/listing.py
+++ b/src/bes/lims/browser/daterangefilter/listing.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of BES.LIMS.
+#
+# BES.LIMS is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2024-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bes.lims.browser.daterangefilter import get_selected_date_range
+from senaite.core.api import dtime
+from senaite.app.listing.interfaces import IListingView
+from senaite.app.listing.interfaces import IListingViewAdapter
+from zope.component import adapter
+from zope.interface import implementer
+from plone.memoize import view
+
+
+@adapter(IListingView)
+@implementer(IListingViewAdapter)
+class DateRangeFilterListingAdapter(object):
+    """A listing adapter that filters items in the listing based on the
+    date range selected.
+    """
+
+    # Order of priority of this subscriber adapter over others
+    priority_order = 9999
+
+    def __init__(self, listing, context):
+        self.listing = listing
+        self.context = context
+
+    def before_render(self):
+        # Get the date range filter specific query
+        query = self.get_date_range_filter_query()
+        if query:
+            # update the content filter for all review states
+            self.update_content_filter(query)
+
+    def folder_item(self, obj, item, index):
+        return item
+
+    @view.memoize
+    def get_date_range_filter_query(self):
+        """Returns a query dict to filter results by the selected date range
+        """
+
+        # get the date range selected for current contact
+        date_range = get_selected_date_range()
+        datetime_from = date_range.get("datetime_from")
+        datetime_to = date_range.get("datetime_to")
+        date_type = date_range.get("date_type")
+        if not datetime_from or not datetime_to:
+            return {}
+
+        date_from_dt = dtime.to_DT(datetime_from)
+        date_to_dt = dtime.to_DT(datetime_to)
+
+        # build the query - filter by the selected date type
+        query = {
+            date_type: {
+                "query": [date_from_dt, date_to_dt],
+                "range": "min:max"
+            }
+        }
+        return query
+
+    def update_content_filter(self, query):
+        """Updates the listing content filter with the query passed in
+        """
+        self.listing.contentFilter.update(query)
+        for review_state in self.listing.review_states:
+            if "contentFilter" not in review_state:
+                review_state["contentFilter"] = {}
+            review_state["contentFilter"].update(query)
+        self.listing.contentFilter.update(query)

--- a/src/bes/lims/browser/daterangefilter/templates/daterangefilter.pt
+++ b/src/bes/lims/browser/daterangefilter/templates/daterangefilter.pt
@@ -1,0 +1,60 @@
+<div i18n:domain="bes.lims">
+
+  <form class="form-inline"
+        id="daterangefilter"
+        name="daterangefilter"
+        method="POST">
+
+    <span i18n:translate="" class="mr-3 font-weight-bold">
+      Date Range:
+    </span>
+
+    <!-- Date type selector -->
+    <label for="date_type" class="field mr-2"
+           i18n:translate="">Filter date by</label>
+    <select id="date_type"
+            name="date_type"
+            class="field mr-2"
+            tal:define="date_types python: view.get_date_types();
+                        selected_date_type python: view.get_date_type()">
+        <option tal:repeat="date_type date_types"
+                tal:attributes="value date_type;
+                                selected python:'selected' if date_type == selected_date_type else None"
+                tal:content="python: date_types.getValue(date_type)"/>
+    </select>
+
+
+    <!-- Date from -->
+    <label for="date_from" class="field mr-2"
+           i18n:translate="">From</label>
+    <input type="date"
+           class="form-control form-control-sm mr-1"
+           id="date_from"
+           name="date_from"
+           tal:attributes="value python: view.get_date_from()"/>
+    <input type="time"
+           class="form-control form-control-sm mr-2"
+           id="time_from"
+           name="time_from"
+           tal:attributes="value python: view.get_time_from()"/>
+
+    <!-- Date to -->
+    <label for="date_to" class="field mr-2"
+           i18n:translate="">To</label>
+    <input type="date"
+           class="form-control form-control-sm mr-1"
+           id="date_to"
+           name="date_to"
+           tal:attributes="value python: view.get_date_to()"/>
+    <input type="time"
+           class="form-control form-control-sm mr-2"
+           id="time_to"
+           name="time_to"
+           tal:attributes="value python: view.get_time_to()"/>
+
+    <button type="submit" i18n:translate=""
+            class="btn btn-sm btn-outline-primary ml-2">Apply</button>
+
+  </form>
+
+</div>

--- a/src/bes/lims/browser/daterangefilter/viewlet.py
+++ b/src/bes/lims/browser/daterangefilter/viewlet.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of BES.LIMS.
+#
+# BES.LIMS is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2024-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bes.lims.browser.daterangefilter import get_selected_date_range
+from bes.lims.browser.daterangefilter import set_selected_date_range
+from bes.lims.config import DATE_TYPES
+from datetime import datetime
+from plone.app.layout.viewlets import ViewletBase
+from plone.memoize import view
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
+
+class DateRangeFilteringViewlet(ViewletBase):
+    """ Print a viewlet to display the date range filtering bar
+    """
+    index = ViewPageTemplateFile("templates/daterangefilter.pt")
+
+    @view.memoize
+    def get_date_range(self):
+        """Returns the selected date range
+        """
+        return get_selected_date_range()
+
+    def get_date_from(self):
+        """Extract date part from datetime_from"""
+        datetime_from = self.get_date_range().get("datetime_from", "")
+        return datetime_from.split(" ")[0] if datetime_from else ""
+
+    def get_time_from(self):
+        """Extract time part from datetime_from"""
+        datetime_from = self.get_date_range().get("datetime_from", "")
+        return datetime_from.split(" ")[1] if " " in datetime_from else "00:00"
+
+    def get_date_to(self):
+        """Extract date part from datetime_to"""
+        datetime_to = self.get_date_range().get("datetime_to", "")
+        return datetime_to.split(" ")[0] if datetime_to else ""
+
+    def get_date_type(self):
+        """Returns the selected date type"""
+        return self.get_date_range().get("date_type", "created")
+
+    def get_time_to(self):
+        """Extract time part from datetime_to"""
+        datetime_to = self.get_date_range().get("datetime_to", "")
+        return datetime_to.split(" ")[1] if " " in datetime_to else "23:59"
+
+    @view.memoize
+    def get_date_types(self):
+        """Return the list of Date Types
+        """
+        return DATE_TYPES
+
+    def render(self):
+        # Check if the form was submitted
+        form_submitted = (
+            "date_from" in self.request.form
+            or "date_to" in self.request.form
+            or "time_from" in self.request.form
+            or "time_to" in self.request.form
+            or "date_type" in self.request.form
+        )
+        if not form_submitted:
+            return self.index()
+
+        # Get the submitted date range, time range and type
+        date_from = self.request.form.get("date_from")
+        date_to = self.request.form.get("date_to")
+        time_from = self.request.form.get("time_from")
+        time_to = self.request.form.get("time_to")
+        date_type = self.request.form.get("date_type")
+
+        # Validate and set default dates if empty
+        if not date_from or not date_to:
+            now = datetime.now()
+            first_day = datetime(now.year, now.month, 1)
+            date_from = date_from or first_day.strftime("%Y-%m-%d")
+            date_to = date_to or now.strftime("%Y-%m-%d")
+
+        # Combine date and time into datetime strings
+        datetime_from = "{} {}".format(date_from, time_from)
+        datetime_to = "{} {}".format(date_to, time_to)
+
+        # Save the selected date range
+        set_selected_date_range(datetime_from, datetime_to, date_type)
+
+        return self.index()

--- a/src/bes/lims/config.py
+++ b/src/bes/lims/config.py
@@ -49,3 +49,13 @@ TARGET_PATIENTS = DisplayList((
     ("a", _("Adult patient")),
     ("p", _("Paediatric patient")),
 ))
+
+DATE_TYPES = DisplayList((
+    ("created", _("Date Registered")),
+    ("getSamplingDate", _("Expected Sampling Date")),
+    ("getDateSampled", _("Date Sampled")),
+    ("getDateReceived", _("Date Received")),
+    ("getDueDate", _("Due Date")),
+    ("getDateVerified", _("Date Verified")),
+    ("getDatePublished", _("Date Published")),
+))


### PR DESCRIPTION
## Description
This Pull Request adds a date range filter bar on top of the samples listing:
<img width="1835" height="295" alt="image" src="https://github.com/user-attachments/assets/32279b64-a2dd-48b8-9fe7-e2ab89647ad3" />

Linked issue: https://github.com/beyondessential/bes.lims/issues/20

## Current behavior
It is not possible to easily filter samples by date range and type


## Desired behavior
It is possible to filter samples by date range and type easily


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
