### PR TITLE
Enable editing of analysis remarks when status is 'to_be_verified'

### DIFF
--- a/src/bes/lims/profiles/default/metadata.xml
+++ b/src/bes/lims/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>1015</version>
+  <version>1016</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/bes/lims/setuphandlers.py
+++ b/src/bes/lims/setuphandlers.py
@@ -124,6 +124,14 @@ WORKFLOWS_TO_UPDATE = {
                 "transitions": ["rollback"],
                 "permissions_copy_from": "rejected",
             },
+            "to_be_verified": {
+                "permissions": {
+                    # allow LabManager, Manager and Scientist to edit remarks
+                    core_permissions.FieldEditAnalysisRemarks: [
+                        "Scientist", "LabManager", "Manager"
+                    ],
+                }
+            },
         },
         "transitions": {
             "set_out_of_stock": {

--- a/src/bes/lims/upgrade/v01_00_000.zcml
+++ b/src/bes/lims/upgrade/v01_00_000.zcml
@@ -3,6 +3,17 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="Enable editing of analysis remarks when status is 'to_be_verified'"
+      description="
+        Permits users assigned to the roles LabManager, Manager, or Scientist to modify remarks associated with analyses
+        that are in the 'To be verified' status.
+      "
+      source="1015"
+      destination="1016"
+      handler=".v01_00_000.enable_analysis_remarks_edition"
+      profile="bes.lims:default"/>
+
+  <genericsetup:upgradeStep
       title="Setup script for exporting data to Tupaia"
       description="Enables the analyses data export for Tupaia"
       source="1014"


### PR DESCRIPTION
## Description

This Pull Request permits users assigned to the roles LabManager, Manager, or Scientist to modify remarks associated with analyses that are in the 'To be verified' status.

## Current behavior

Users cannot edit analysis remarks when status is 'to_be_verified'

## Desired behavior

Users with enough privileges can edit analysis remarks when status is 'to_be_verified'

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
