### PR TITLE
Fix date range filter timezone handling

### DIFF
--- a/src/bes/lims/browser/daterangefilter/listing.py
+++ b/src/bes/lims/browser/daterangefilter/listing.py
@@ -18,33 +18,35 @@
 # Copyright 2024-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from datetime import datetime
-
+import pytz
 from bes.lims.browser.daterangefilter import get_selected_date_range_config
-from plone import api as ploneapi
-from senaite.core.api import dtime
+from bika.lims import api
+from plone.memoize import view
 from senaite.app.listing.interfaces import IListingView
 from senaite.app.listing.interfaces import IListingViewAdapter
+from senaite.core.api import dtime
 from zope.component import adapter
 from zope.interface import implementer
-from plone.memoize import view
 
 
 def get_timezone():
-    """Return the portal timezone, with safe fallbacks.
+    """Return the effective timezone for the current user.
+    Prefer the user's timezone if set and valid, otherwise fall back to the
+    site timezone, and finally to the system (OS) timezone.
     """
-    tz = ploneapi.portal.get_registry_record("plone.portal_timezone")
-    if not tz or not dtime.is_valid_timezone(tz):
-        tz = dtime.get_os_timezone()
-    return tz
+    # User's default TZ has priority over portal's
+    user = api.get_current_user()
+    tz = user.getProperty("timezone")
+    if dtime.is_valid_timezone(tz):
+        return tz
 
+    # get the portal's default timezone
+    tz = api.get_registry_record("plone.portal_timezone")
+    if dtime.is_valid_timezone(tz):
+        return tz
 
-def parse_local_datetime(value, timezone):
-    if not value:
-        return None
-    dt = datetime.strptime(value, "%Y-%m-%d %H:%M")
-    dt = dtime.to_zone(dt, timezone)
-    return dtime.to_DT(dt)
+    # No TZ set or not valid, return OS's
+    return dtime.get_os_timezone()
 
 
 @adapter(IListingView)
@@ -83,20 +85,30 @@ class DateRangeFilterListingAdapter(object):
         if not date_range.get("filter_enabled", False):
             return {}
 
-        datetime_from = date_range.get("datetime_from")
-        datetime_to = date_range.get("datetime_to")
+        # get the date range and index name to search by (date_type)
+        dt_from = dtime.to_dt(date_range.get("datetime_from"))
+        dt_to = dtime.to_dt(date_range.get("datetime_to"))
         date_type = date_range.get("date_type")
-        if not datetime_from and not datetime_to:
+        if not all([dt_from, dt_to, date_type]):
             return {}
 
+        # Dates submitted with the form are timezone-naive. We therefore
+        # explicitly set (without shifting the time value) the current
+        # user/site/system timezone so that searches align with the timezone
+        # used during indexing.
         timezone = get_timezone()
-        date_from_dt = parse_local_datetime(datetime_from, timezone)
-        date_to_dt = parse_local_datetime(datetime_to, timezone)
+        tz_info = pytz.timezone(timezone)
+        dt_from = dt_from.replace(tzinfo=tz_info)
+        dt_to = dt_to.replace(tzinfo=tz_info)
+
+        # convert to Zope's DateTime
+        dt_from = dtime.to_DT(dt_from)
+        dt_to = dtime.to_DT(dt_to)
 
         # build the query - filter by the selected date type
         query = {
             date_type: {
-                "query": [date_from_dt, date_to_dt],
+                "query": [dt_from, dt_to],
                 "range": "min:max"
             }
         }


### PR DESCRIPTION
## Description
This PR adjusts the date range filter to interpret input dates in the portal timezone (with OS fallback) before building catalog queries, preventing off‑by‑one‑day results when server and portal TZ differ

Linked issue: https://github.com/beyondessential/bes.lims/issues/82

## Current behavior
Date range filtering uses timezone‑naive values, so results can include items outside the selected range when server and portal timezones differ

## Desired behavior
Date range filtering respects the portal timezone (fallback to OS timezone), so the results match the selected range in the UI

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
