### PR TITLE
Fix Tamanu sync freezing due to missing HTTP timeouts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0
 -----
 
+- #125 Fix Tamanu sync freezing due to missing HTTP timeouts
 - #124 Add result variables and improve result formatting to Tupaia export file
 - #119 Fix empty pdf when notifying DiagnosticReport to Tamanu
 - #116 Compatibility with core#2831 (Migrate ARReport to Dexterity)

--- a/scripts/sync_tamanu.py
+++ b/scripts/sync_tamanu.py
@@ -45,7 +45,7 @@ from bika.lims.api import security as sapi
 from bika.lims.utils.analysisrequest import \
     create_analysisrequest as create_sample
 from bika.lims.workflow import doActionFor
-from requests import ConnectionError
+from requests.exceptions import RequestException
 from senaite.core.api import dtime
 from senaite.core.catalog import CLIENT_CATALOG
 from senaite.core.catalog import CONTACT_CATALOG
@@ -190,8 +190,10 @@ def get_client(service_request):
     }
     brains = api.search(query, CLIENT_CATALOG)
     if not brains:
-        container = api.get_portal().clients
-        return tapi.create_object(container, resource, "Client")
+        if api.get_registry_record("create_clients_on_sync", default=False):
+            container = api.get_portal().clients
+            return tapi.create_object(container, resource, "Client")
+        return None
 
     # link the resource to this Client object
     client = api.get_object(brains[0])
@@ -902,7 +904,7 @@ def main(app):
     try:
         # Call the sync function
         sync_func(session, since)
-    except ConnectionError as e:
+    except RequestException as e:
         connection_error(str(e))
 
     if args.dry:

--- a/scripts/sync_tamanu.py
+++ b/scripts/sync_tamanu.py
@@ -190,10 +190,8 @@ def get_client(service_request):
     }
     brains = api.search(query, CLIENT_CATALOG)
     if not brains:
-        if api.get_registry_record("create_clients_on_sync", default=False):
-            container = api.get_portal().clients
-            return tapi.create_object(container, resource, "Client")
-        return None
+        container = api.get_portal().clients
+        return tapi.create_object(container, resource, "Client")
 
     # link the resource to this Client object
     client = api.get_object(brains[0])

--- a/src/bes/lims/tamanu/session.py
+++ b/src/bes/lims/tamanu/session.py
@@ -43,6 +43,9 @@ HEADERS = (
     ("Content-Type", "application/json"),
 )
 
+# request timeout in seconds (connect, read)
+TIMEOUT = (10, 120)
+
 
 class TamanuSession(object):
 
@@ -83,6 +86,9 @@ class TamanuSession(object):
         # raise on error?
         raise_for_status = kwargs.pop("raise_for_status", False)
 
+        # timeout
+        timeout = kwargs.pop("timeout", TIMEOUT)
+
         # add the default headers
         headers = kwargs.pop("headers", {})
         headers.update(dict(HEADERS))
@@ -96,7 +102,8 @@ class TamanuSession(object):
         # Send the POST request
         logger.info("[POST] {}".format(url))
         logger.debug("[POST PAYLOAD] {}".format(repr(payload)))
-        resp = requests.post(url, data=json.dumps(payload), **kwargs)
+        resp = requests.post(url, data=json.dumps(payload), timeout=timeout,
+                             **kwargs)
         if raise_for_status:
             resp.raise_for_status()
         code = resp.status_code
@@ -109,6 +116,12 @@ class TamanuSession(object):
     def get(self, endpoint, params=None, **kwargs):
         url = self.get_url(endpoint)
 
+        # raise on error?
+        raise_for_status = kwargs.pop("raise_for_status", False)
+
+        # timeout
+        timeout = kwargs.pop("timeout", TIMEOUT)
+
         # add the default headers
         headers = kwargs.pop("headers", {})
         headers.update(dict(HEADERS))
@@ -119,10 +132,16 @@ class TamanuSession(object):
 
         # do the GET request
         logger.info("[GET] {} (params={})".format(url, repr(params)))
-        resp = requests.get(url, params=params, **kwargs)
+        resp = requests.get(url, params=params, timeout=timeout, **kwargs)
+        if raise_for_status:
+            resp.raise_for_status()
 
         # return the response
-        return resp.json() or {}
+        try:
+            return resp.json() or {}
+        except ValueError:
+            logger.error("[ERROR {}]: {}".format(resp.status_code, resp.content))
+            return {}
 
     def get_resource_by_uid(self, resource_type, uid):
         endpoint = "{}/{}".format(resource_type, uid)

--- a/templates/sync_tamanu.in
+++ b/templates/sync_tamanu.in
@@ -10,7 +10,10 @@ BIN_DIR=${buildout:directory}/bin
 SRC_DIR=${buildout:directory}/src/bes.lims/scripts
 ZEO_DIR=${buildout:var-dir}/${sync_tamanu:zeoclient}
 FLOCK="flock -n /tmp/sync_tamanu.lock"
-TIMEOUT="timeout 240"
+
+# Apply a `timeout 840` (14 min) as a safety net, so even if a process hangs
+# despite HTTP timeouts, it gets killed before the next 15-minute cron run
+TIMEOUT="timeout 840"
 
 # Synchronize service requests
 $FLOCK $TIMEOUT $BIN_DIR/${sync_tamanu:zeoclient} run $SRC_DIR/sync_tamanu.py -th $HOST -tu $CREDS -r ServiceRequest -s $SINCE_SERVICE_REQUEST -c $ZEO_DIR |& tee -a $ZEO_DIR/event.log

--- a/templates/sync_tamanu.in
+++ b/templates/sync_tamanu.in
@@ -10,12 +10,13 @@ BIN_DIR=${buildout:directory}/bin
 SRC_DIR=${buildout:directory}/src/bes.lims/scripts
 ZEO_DIR=${buildout:var-dir}/${sync_tamanu:zeoclient}
 FLOCK="flock -n /tmp/sync_tamanu.lock"
+TIMEOUT="timeout 240"
 
 # Synchronize service requests
-$FLOCK $BIN_DIR/${sync_tamanu:zeoclient} run $SRC_DIR/sync_tamanu.py -th $HOST -tu $CREDS -r ServiceRequest -s $SINCE_SERVICE_REQUEST -c $ZEO_DIR |& tee -a $ZEO_DIR/event.log
+$FLOCK $TIMEOUT $BIN_DIR/${sync_tamanu:zeoclient} run $SRC_DIR/sync_tamanu.py -th $HOST -tu $CREDS -r ServiceRequest -s $SINCE_SERVICE_REQUEST -c $ZEO_DIR |& tee -a $ZEO_DIR/event.log
 
 # Synchronize patients
-$FLOCK $BIN_DIR/${sync_tamanu:zeoclient} run $SRC_DIR/sync_tamanu.py -th $HOST -tu $CREDS -r Patient -s $SINCE_PATIENTS -c $ZEO_DIR |& tee -a $ZEO_DIR/event.log
+$FLOCK $TIMEOUT $BIN_DIR/${sync_tamanu:zeoclient} run $SRC_DIR/sync_tamanu.py -th $HOST -tu $CREDS -r Patient -s $SINCE_PATIENTS -c $ZEO_DIR |& tee -a $ZEO_DIR/event.log
 
 # Run Tamanu specific tasks
-$FLOCK $BIN_DIR/${sync_tamanu:zeoclient} run $SRC_DIR/exec_tamanu_tasks.py -m 10 |& tee -a $ZEO_DIR/event.log
+$FLOCK $TIMEOUT $BIN_DIR/${sync_tamanu:zeoclient} run $SRC_DIR/exec_tamanu_tasks.py -m 10 |& tee -a $ZEO_DIR/event.log


### PR DESCRIPTION
## Description

This Pull Request adds a default timeout 10s (connect) + 120s (read) for requests against Tamanu server to fail gracefully instead of blocking forever.

## Current behavior

The Tamanu sync cronjob (running every 5 minutes) frequently gets stuck indefinitely. When the Tamanu server is slow or unresponsive, HTTP requests in `TamanuSession.post()` and `TamanuSession.get()` block forever because the `requests` library defaults to no timeout. The frozen process holds the `flock` lock, preventing all subsequent cron runs until someone manually kills the process.                                                                                      

Additionally, the exception handler in `sync_tamanu.py` only catches `ConnectionError`, so timeout errors and other HTTP failures propagate unhandled.

## Desired behavior

HTTP requests fail gracefully after a reasonable timeout instead of blocking forever


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
