### PR TITLE
Add Text control type for interim result variables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0
 -----
 
+- #128 Add Text control type for interim result variables
 - #124 Add result variables and improve result formatting to Tupaia export file
 - #119 Fix empty pdf when notifying DiagnosticReport to Tamanu
 - #116 Compatibility with core#2831 (Migrate ARReport to Dexterity)

--- a/src/bes/lims/browser/sample/analyses.py
+++ b/src/bes/lims/browser/sample/analyses.py
@@ -19,7 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 import collections
-
+import cgi
 from bes.lims import messageFactory as _
 from bes.lims.reflex import get_reflex_testing_adapter
 from bika.lims import api
@@ -61,9 +61,37 @@ class SampleAnalysesListingAdapter(object):
     def folder_item(self, obj, item, index):
         # render results range or range comment
         self.render_results_range(obj, item)
+        # keep interim multiline values in readonly display
+        self.render_interim_line_breaks(item)
         # force full view reload if required
         self.render_reload(obj, item)
         return item
+
+    def format_interim_text(self, value):
+        """Formats interim string/text values to keep line breaks
+        """
+        result = value if api.is_string(value) else str(value)
+        result = cgi.escape(result)
+        return result.replace("\n", "<br/>")
+
+    def render_interim_line_breaks(self, item):
+        """Converts interim new lines to <br/> in readonly render payload."""
+        interims = item.get("interimfields") or []
+        allow_edit = item.get("allow_edit", [])
+        for interim in interims:
+            keyword = interim.get("keyword", "")
+            if not keyword:
+                continue
+
+            result_type = interim.get("result_type")
+            if not interim.get("value"):
+                continue
+
+            if result_type in ["string", "text"]:
+                formatted = self.format_interim_text(interim.get("value"))
+                interim["formatted_value"] = formatted
+                if keyword not in allow_edit:
+                    interim["value"] = formatted
 
     def render_reload(self, obj, item):
         """Assign the item's reload attribute with the actions for the given

--- a/src/bes/lims/config.py
+++ b/src/bes/lims/config.py
@@ -59,3 +59,15 @@ DATE_TYPES = DisplayList((
     ("getDateVerified", _("Date Verified")),
     ("getDatePublished", _("Date Published")),
 ))
+
+RESULT_TYPES = DisplayList((
+    ("", _("Numeric")),
+    ("string", _("String")),
+    ("datetime", _("Datetime")),
+    ("select", _("Selection list")),
+    ("multiselect", _("Multiple selection")),
+    ("multiselect_duplicates", _("Multiple selection (with duplicates)")),
+    ("multichoice", _("Multiple choices")),
+    ("multivalue", _("Multiple values")),
+    ("text", _("Text")),
+))

--- a/src/bes/lims/extender/__init__.py
+++ b/src/bes/lims/extender/__init__.py
@@ -17,3 +17,35 @@
 #
 # Copyright 2024-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
+
+from bes.lims import logger
+
+
+def update_field(schema, field_id, field_info):
+    """Updates the schema field for with the field_info provided
+    """
+    # Field properties
+    field = schema[field_id]
+    field.schemata = field_info.get("schemata", field.schemata)
+    props = filter(lambda f: f != "widget", field_info.keys())
+    for prop_id in props:
+        if not hasattr(field, prop_id):
+            logger.warn("Field property {} is missing".format(prop_id))
+            continue
+        setattr(field, prop_id, field_info.get(prop_id))
+        if prop_id in ["validators", "subfield_validators"]:
+            # Resolve validators in the service
+            if hasattr(field, "_validationLayer"):
+                field._validationLayer()
+
+    # Widget properties
+    widget = field.widget
+    props = field_info.get("widget", {})
+    if isinstance(props, dict):
+        for prop_id, prop_value in props.items():
+            if not hasattr(widget, prop_id):
+                logger.warn("Widget Property {} is missing".format(prop_id))
+                continue
+            setattr(widget, prop_id, prop_value)
+    elif props:
+        field.widget = props

--- a/src/bes/lims/extender/analysisservice.py
+++ b/src/bes/lims/extender/analysisservice.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of BES.LIMS.
+#
+# BES.LIMS is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2026 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from archetypes.schemaextender.interfaces import IBrowserLayerAwareExtender
+from archetypes.schemaextender.interfaces import ISchemaModifier
+from bes.lims.interfaces import IBESLimsLayer
+from bes.lims.config import RESULT_TYPES
+from bes.lims.extender import update_field
+from bika.lims.interfaces import IAnalysisService
+from zope.component import adapter
+from zope.interface import implementer
+
+
+UPDATED_FIELDS = [
+    ("InterimFields", {
+        "subfield_vocabularies": {
+            "result_type": RESULT_TYPES,
+        },
+    }),
+]
+
+
+@adapter(IAnalysisService)
+@implementer(ISchemaModifier, IBrowserLayerAwareExtender)
+class AnalysisServiceInterimFieldsSchemaModifier(object):
+    """Updates InterimFields schema for AnalysisService.
+    """
+
+    layer = IBESLimsLayer
+
+    def __init__(self, context):
+        self.context = context
+
+    def fiddle(self, schema):
+        # Update some fields (title, description, etc.)
+        map(lambda f: update_field(schema, f[0], f[1]), UPDATED_FIELDS)
+        return schema

--- a/src/bes/lims/extender/analysisservice.zcml
+++ b/src/bes/lims/extender/analysisservice.zcml
@@ -1,0 +1,8 @@
+<configure xmlns="http://namespaces.zope.org/zope">
+
+  <adapter
+      name="bes.lims.analysisservice.interimfields.schemamodifier"
+      provides="archetypes.schemaextender.interfaces.ISchemaModifier"
+      factory=".analysisservice.AnalysisServiceInterimFieldsSchemaModifier"/>
+
+</configure>

--- a/src/bes/lims/extender/configure.zcml
+++ b/src/bes/lims/extender/configure.zcml
@@ -7,5 +7,6 @@
   <include file="client.zcml"/>
   <include file="setup.zcml"/>
   <include file="analysisrequest.zcml"/>
+  <include file="analysisservice.zcml"/>
 
 </configure>


### PR DESCRIPTION
## Description
This PR adds **"Text"** as a selectable Control type when configuring new interim/result variables on Analysis Services.

Linked issue: https://github.com/beyondessential/bes.lims/issues/118

## Current behavior
- When adding a new result variable, Control type does not include a **Text** option.
- In readonly views, multiline interim values may appear as a single line (line breaks not preserved).

## Desired behavior
- **Text** is available as a Control type when adding new result variables.
- Users can store textual interim result values using the new `text` type.
- Readonly display preserves line breaks for `string`/`text` interim values for better readability

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
