### PR TITLE
Setup registry settings on install

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0
 -----
 
+- #130 Setup registry settings on install
 - #124 Add result variables and improve result formatting to Tupaia export file
 - #119 Fix empty pdf when notifying DiagnosticReport to Tamanu
 - #116 Compatibility with core#2831 (Migrate ARReport to Dexterity)

--- a/src/bes/lims/config.py
+++ b/src/bes/lims/config.py
@@ -59,3 +59,80 @@ DATE_TYPES = DisplayList((
     ("getDateVerified", _("Date Verified")),
     ("getDatePublished", _("Date Published")),
 ))
+
+REGISTRY_SETTINGS = [
+    # When disabled (default), ServiceRequests from Tamanu belonging to a
+    # facility without a matching Client in SENAITE are skipped. This allows
+    # multiple SENAITE instances to share the same Tamanu, each processing
+    # only the ServiceRequests for its own facility.
+    ("create_clients_on_sync", False),
+    # Enable Ajax transitions
+    ("listing_enable_ajax_transitions", True),
+    # Transitions that are processed sequentially via ajax
+    ("listing_active_ajax_transitions", [
+        "activate",
+        "cancel",
+        "deactivate",
+        "receive",
+        "reinstate",
+        "reject",
+        "retest",
+        "retract",
+        "submit",
+        "verify",
+        # transitions from senaite.referral
+        "receive_inbound_sample",
+        "reject_inbound_sample",
+    ]),
+    # Additional catalogs for default portal types
+    ("catalog_mappings", {}),
+    # Content types to skip by default on content structure export
+    ("generic_setup_skip_export_types", [
+        # plone
+        "Document",
+        # senaite.core
+        "AnalysisRequest",
+        "ARReport",
+        "Attachment",
+        "AutoImportLog",
+        "Batch",
+        "BatchFolder",
+        "Client",
+        "Contact",
+        "Contacts",
+        "ClientFolder",
+        "LabContact",
+        "LabContacts",
+        "Laboratory",
+        "Invoice",
+        "Pricelist",
+        "PricelistFolder",
+        "ReferenceSample",
+        "ReferenceSamplesFolder",
+        "Report",
+        "ResultsReport",
+        "Samples",
+        "Worksheet",
+        "WorksheetFolder",
+        "Worksheets",
+        # senaite.databox
+        "DataBox",
+        "DataBoxFolder",
+        # senaite.patient
+        "Patient",
+        "PatientFolder",
+        # senaite.referral
+        "ExternalLaboratory",
+        "ExternalLaboratoryFolder",
+        "InboundSample",
+        "InboundSampleShipment",
+        "OutboundSampleShipment",
+        "ShipmentFolder",
+        # senaite.storage
+        "StorageContainer",
+        "StorageFacility",
+        "StoragePosition",
+        "StorageRootFolder",
+        "StorageSamplesContainer",
+    ]),
+]

--- a/src/bes/lims/setuphandlers.py
+++ b/src/bes/lims/setuphandlers.py
@@ -21,6 +21,7 @@
 from bes.lims import logger
 from bes.lims import permissions
 from bes.lims import PRODUCT_NAME
+from bes.lims.config import REGISTRY_SETTINGS
 from bika.lims import api
 from bika.lims.api import security as sapi
 from plone import api as ploneapi
@@ -30,6 +31,7 @@ from senaite.core.api import workflow as wapi
 from senaite.core.catalog import ANALYSIS_CATALOG
 from senaite.core.catalog import SAMPLE_CATALOG
 from senaite.core.catalog import SETUP_CATALOG
+from senaite.core.registry import set_registry_record
 from senaite.core.setuphandlers import setup_core_catalogs
 from senaite.core.setuphandlers import setup_other_catalogs
 from senaite.core.workflow import ANALYSIS_WORKFLOW
@@ -217,6 +219,9 @@ def setup_handler(context):
     # Setup workflows
     setup_workflows(portal)
 
+    # Setup registry settings
+    setup_senaite_registry(portal)
+
     # Setup microbiology department and assign ast-analyses
     setup_microbiology_department(portal)
 
@@ -262,6 +267,15 @@ def setup_workflows(portal):
     for wf_id, settings in WORKFLOWS_TO_UPDATE.items():
         wapi.update_workflow(wf_id, **settings)
     logger.info("Setup workflows [DONE]")
+
+
+def setup_senaite_registry(portal):
+    """Setup the default settings for senaite registry
+    """
+    logger.info("Setup registry settings ...")
+    for key, val in REGISTRY_SETTINGS:
+        set_registry_record(key, val)
+    logger.info("Setup registry settings [DONE]")
 
 
 def setup_roles(portal):


### PR DESCRIPTION
## Description

This Pull Request ensures that the default values for registry are properly setup on install

## Current behavior

Registry settings are not set by default on install

## Desired behavior

Registry settings are set by default on install

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
