### PR TITLE
Centralize Tamanu host and credentials in the control panel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0
 -----
 
+- #132 Centralize Tamanu host and credentials in the control panel
 - #126 Disable automatic client creation on Tamanu sync by default
 - #124 Add result variables and improve result formatting to Tupaia export file
 - #119 Fix empty pdf when notifying DiagnosticReport to Tamanu

--- a/scripts/sync_tamanu.py
+++ b/scripts/sync_tamanu.py
@@ -63,14 +63,6 @@ parser = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawTextHelpFormatter)
 
 parser.add_argument(
-    "-th", "--tamanu_host",
-    help="URL from the Tamanu instance to extract the data from"
-)
-parser.add_argument(
-    "-tu", "--tamanu_user",
-    help="User and password in the <username>:<password> form"
-)
-parser.add_argument(
     "-su", "--senaite_user",
     help="SENAITE user"
 )
@@ -849,20 +841,8 @@ def main(app):
         parser.exit()
         return
 
-    # get the remote host
-    host = args.tamanu_host
-    if not host:
-        error("Remote URL is missing")
-
     # get the local filesystem path for cached content
     _cache_path = args.cache
-
-    # get the user and password
-    try:
-        user, password = args.tamanu_user.split(":")
-    except (AttributeError, ValueError):
-        error("Credentials are missing or not valid format")
-        return
 
     # get since dhms
     since = args.since or DEFAULT_SINCE
@@ -888,6 +868,14 @@ def main(app):
     # Setup environment
     username = args.senaite_user or USERNAME
     setup_script_environment(app, username=username, logger=logger)
+
+    # Host and credentials are read from the Tamanu control panel once the
+    # portal context is available. Configure them at /@@tamanu-controlpanel.
+    host, user, password = tapi.get_tamanu_settings()
+    if not host:
+        error("Tamanu host is not configured in the control panel")
+    if not user or not password:
+        error("Tamanu credentials are not configured in the control panel")
 
     # do the work
     logger.info("-" * 79)

--- a/src/bes/lims/profiles/default/metadata.xml
+++ b/src/bes/lims/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>1018</version>
+  <version>1019</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/bes/lims/tamanu/api.py
+++ b/src/bes/lims/tamanu/api.py
@@ -76,9 +76,24 @@ def get_tamanu_host(obj):
     if is_tamanu_resource(obj):
         return obj.session.host
     if is_tamanu_content(obj):
-        storage = get_tamanu_storage(obj)
-        return storage.get("host", None)
+        host, _email, _password = get_tamanu_settings()
+        return host
     return None
+
+
+def get_tamanu_settings():
+    """Returns the (host, email, password) tuple configured in the Tamanu
+    control panel, used for all outbound requests against Tamanu content
+    """
+    from plone.registry.interfaces import IRegistry
+    from zope.component import getUtility
+    registry = getUtility(IRegistry)
+    prefix = "senaite.tamanu."
+    return (
+        registry.get(prefix + "host"),
+        registry.get(prefix + "email"),
+        registry.get(prefix + "password"),
+    )
 
 
 def get_tamanu_modified(obj):
@@ -109,21 +124,14 @@ def get_tamanu_session(host, email, password, login=True):
 def get_tamanu_session_for(obj, login=True):
     """Returns a Tamanu Session for the given object
     """
-    # TODO Use a singleton utility to get tamanu session
     if is_tamanu_resource(obj):
         return obj.session
     if is_tamanu_content(obj):
-        host = get_tamanu_host(obj)
+        host, email, password = get_tamanu_settings()
         if not host:
-            raise ValueError("Tamanu content, but no host: %s" % repr(obj))
-
-        # get the creds
-        storage = get_tamanu_storage(obj)
-        email, password = storage.get("auth")
-
-        # create the session
+            raise ValueError(
+                "Tamanu host is not configured in the control panel")
         return get_tamanu_session(host, email, password, login=login)
-
     return None
 
 
@@ -242,9 +250,6 @@ def link_tamanu_resource(obj, resource):
     annotation = get_tamanu_storage(obj)
     annotation["uid"] = resource.UID
     annotation["data"] = resource.to_dict()
-    annotation["host"] = resource.session.host
-    # TODO Rely on an utility instead of storing auth creds
-    annotation["auth"] = resource.session._auth
 
     # index tamanu_uid from uid_catalog
     catalog_object(obj)

--- a/src/bes/lims/tamanu/browser/controlpanel.py
+++ b/src/bes/lims/tamanu/browser/controlpanel.py
@@ -3,9 +3,13 @@
 from bes.lims.tamanu import _
 from plone.app.registry.browser.controlpanel import ControlPanelFormWrapper
 from plone.app.registry.browser.controlpanel import RegistryEditForm
+from plone.registry.interfaces import IRegistry
 from plone.supermodel import model
 from plone.z3cform import layout
 from zope import schema
+from zope.component import getUtility
+
+PASSWORD_PLACEHOLDER = u"•" * 12
 
 
 class ITamanuControlPanel(model.Schema):
@@ -73,6 +77,28 @@ class TamanuControlPanelForm(RegistryEditForm):
         u"controlpanel_tamanu",
         default=u"Tamanu Synchronization Settings"
     )
+
+    def updateWidgets(self):
+        super(TamanuControlPanelForm, self).updateWidgets()
+        # The password widget's template intentionally never emits a `value`
+        # attribute so the secret is not round-tripped to the browser. That
+        # makes a configured password look identical to an unconfigured one.
+        # Render dots as a placeholder when a password is stored, so admins
+        # can tell at a glance that a value is set.
+        pw_widget = self.widgets.get("password")
+        if pw_widget is None:
+            return
+        registry = getUtility(IRegistry)
+        if registry.get(self.schema_prefix + ".password"):
+            pw_widget.placeholder = PASSWORD_PLACEHOLDER
+
+    def applyChanges(self, data):
+        # Treat an empty password submission as "do not change", so that
+        # re-saving the form without retyping the password preserves the
+        # stored value. To clear the password, unset it via the registry.
+        if not data.get("password"):
+            data.pop("password", None)
+        return super(TamanuControlPanelForm, self).applyChanges(data)
 
 
 TamanuControlPanelView = layout.wrap_form(

--- a/src/bes/lims/tamanu/browser/controlpanel.py
+++ b/src/bes/lims/tamanu/browser/controlpanel.py
@@ -12,6 +12,43 @@ class ITamanuControlPanel(model.Schema):
     """Control panel settings for tamanu sync
     """
 
+    host = schema.URI(
+        title=_(
+            u"title_tamanu_settings_host",
+            default=u"Tamanu host"),
+        description=_(
+            u"description_tamanu_settings_host",
+            default=u"Base URL of the Tamanu instance this LIMS syncs with. "
+                    u"Used for all outbound requests targeting Tamanu "
+                    u"resources previously imported into SENAITE."
+        ),
+        required=False,
+    )
+
+    email = schema.TextLine(
+        title=_(
+            u"title_tamanu_settings_email",
+            default=u"Integration account email"),
+        description=_(
+            u"description_tamanu_settings_email",
+            default=u"Email of the Tamanu account used by SENAITE to "
+                    u"authenticate outbound requests."
+        ),
+        required=False,
+    )
+
+    password = schema.Password(
+        title=_(
+            u"title_tamanu_settings_password",
+            default=u"Integration account password"),
+        description=_(
+            u"description_tamanu_settings_password",
+            default=u"Password of the Tamanu account used by SENAITE to "
+                    u"authenticate outbound requests."
+        ),
+        required=False,
+    )
+
     create_clients_on_sync = schema.Bool(
         title=_(
             u"title_tamanu_settings_create_clients_on_sync",

--- a/src/bes/lims/upgrade/v01_00_000.py
+++ b/src/bes/lims/upgrade/v01_00_000.py
@@ -527,3 +527,16 @@ def setup_tamanu_controlpanel(tool):
     setup.runImportStepFromProfile(profile, "plone.app.registry")
     setup.runImportStepFromProfile(profile, "controlpanel")
     logger.info("Setup Tamanu controlpanel [DONE]]")
+
+
+def setup_tamanu_host_credentials(tool):
+    """Registers the new host/email/password fields of the Tamanu control
+    panel. Outbound requests against previously imported Tamanu content now
+    consult the control panel instead of each object's annotation storage,
+    so admins must set these values after the upgrade.
+    """
+    logger.info("Setup Tamanu host and credentials ...")
+    portal = tool.aq_inner.aq_parent
+    setup = portal.portal_setup
+    setup.runImportStepFromProfile(profile, "plone.app.registry")
+    logger.info("Setup Tamanu host and credentials [DONE]")

--- a/src/bes/lims/upgrade/v01_00_000.zcml
+++ b/src/bes/lims/upgrade/v01_00_000.zcml
@@ -3,6 +3,18 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="Add Tamanu host and credentials to control panel"
+      description="
+        Registers the new host, email and password fields of the Tamanu
+        control panel so they can be configured centrally, replacing the
+        per-object host and auth that used to be kept in annotation storage.
+      "
+      source="1018"
+      destination="1019"
+      handler=".v01_00_000.setup_tamanu_host_credentials"
+      profile="bes.lims:default"/>
+
+  <genericsetup:upgradeStep
       title="Setup Tamanu control panel"
       description="Setup the Tamanu's synchronization configuration view"
       source="1017"

--- a/templates/sync_tamanu.in
+++ b/templates/sync_tamanu.in
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-HOST=${sync_tamanu:host}
-CREDS=${sync_tamanu:credentials}
-
 SINCE_SERVICE_REQUEST=${sync_tamanu:sample_since}
 SINCE_PATIENTS=${sync_tamanu:patients_since}
 
@@ -11,11 +8,14 @@ SRC_DIR=${buildout:directory}/src/bes.lims/scripts
 ZEO_DIR=${buildout:var-dir}/${sync_tamanu:zeoclient}
 FLOCK="flock -n /tmp/sync_tamanu.lock"
 
+# Tamanu host and credentials are read from the control panel
+# (@@tamanu-controlpanel). Configure them there before running this script.
+
 # Synchronize service requests
-$FLOCK $BIN_DIR/${sync_tamanu:zeoclient} run $SRC_DIR/sync_tamanu.py -th $HOST -tu $CREDS -r ServiceRequest -s $SINCE_SERVICE_REQUEST -c $ZEO_DIR |& tee -a $ZEO_DIR/event.log
+$FLOCK $BIN_DIR/${sync_tamanu:zeoclient} run $SRC_DIR/sync_tamanu.py -r ServiceRequest -s $SINCE_SERVICE_REQUEST -c $ZEO_DIR |& tee -a $ZEO_DIR/event.log
 
 # Synchronize patients
-$FLOCK $BIN_DIR/${sync_tamanu:zeoclient} run $SRC_DIR/sync_tamanu.py -th $HOST -tu $CREDS -r Patient -s $SINCE_PATIENTS -c $ZEO_DIR |& tee -a $ZEO_DIR/event.log
+$FLOCK $BIN_DIR/${sync_tamanu:zeoclient} run $SRC_DIR/sync_tamanu.py -r Patient -s $SINCE_PATIENTS -c $ZEO_DIR |& tee -a $ZEO_DIR/event.log
 
 # Run Tamanu specific tasks
 $FLOCK $BIN_DIR/${sync_tamanu:zeoclient} run $SRC_DIR/exec_tamanu_tasks.py -m 10 |& tee -a $ZEO_DIR/event.log

--- a/templates/sync_tamanu_patients.in
+++ b/templates/sync_tamanu_patients.in
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-HOST=${buildout:tamanu-host}
-CREDS=${buildout:tamanu-user}
-
 BASE=${buildout:directory}
 BIN_DIR=${buildout:directory}/bin
 SRC_DIR=${buildout:directory}/src
@@ -15,4 +12,7 @@ if [ -n "$1" ]; then
   SINCE=$1
 fi
 
-$BIN_DIR/client_reserved run $SRC -th $HOST -tu $CREDS -r Patient -s $SINCE -c $CACHE_DIR
+# Tamanu host and credentials are read from the control panel
+# (@@tamanu-controlpanel). Configure them there before running this script.
+
+$BIN_DIR/client_reserved run $SRC -r Patient -s $SINCE -c $CACHE_DIR

--- a/templates/sync_tamanu_requests.in
+++ b/templates/sync_tamanu_requests.in
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-HOST=${buildout:tamanu-host}
-CREDS=${buildout:tamanu-user}
-
 BASE=${buildout:directory}
 BIN_DIR=${buildout:directory}/bin
 SRC_DIR=${buildout:directory}/src
@@ -15,4 +12,7 @@ if [ -n "$1" ]; then
   SINCE=$1
 fi
 
-$BIN_DIR/client_reserved run $SRC -th $HOST -tu $CREDS -r ServiceRequest -s $SINCE -c $CACHE_DIR
+# Tamanu host and credentials are read from the control panel
+# (@@tamanu-controlpanel). Configure them there before running this script.
+
+$BIN_DIR/client_reserved run $SRC -r ServiceRequest -s $SINCE -c $CACHE_DIR


### PR DESCRIPTION
## Description

Moves the Tamanu host and credentials out of per-object annotation storage and out of CLI/buildout arguments, into a single place in the Tamanu control panel (`@@tamanu-controlpanel`). Outbound requests against previously imported Tamanu content, as well as the `sync_tamanu.py` cron-driven script, now consult the registry instead.

Linked issue: https://github.com/beyondessential/bes.lims/issues/122

<img width="864" height="510" alt="20260422155902" src="https://github.com/user-attachments/assets/6948387d-1627-43fd-a22f-5056084b0639" />



--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
