### PR TITLE
Add ProfileAnalyses column to Analysis Profiles listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0
 -----
 
+- #136 Add ProfileAnalyses column to Analysis Profiles listing
 - #134 Include the name of the verifier when sending results to Tamanu
 - #131 Push FHIR Observations to Tamanu using a FHIR Transaction Bundle
 - #133 Add microbiology statistic reports for contamination, pathogen, AST panel, and sample rejection

--- a/src/bes/lims/adapters/listing/analysisprofiles.py
+++ b/src/bes/lims/adapters/listing/analysisprofiles.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of BES.LIMS.
+#
+# BES.LIMS is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2024-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.lims import api
+from bes.lims import _
+from senaite.app.listing.interfaces import IListingView
+from senaite.app.listing.interfaces import IListingViewAdapter
+from senaite.core.browser.controlpanel.analysisprofiles.view import get_link_for
+from zope.component import adapts
+from zope.interface import implements
+
+
+class AnalysisProfilesListingAdapter(object):
+    """Adapter for analysis profiles listings
+    """
+    adapts(IListingView)
+    implements(IListingViewAdapter)
+
+    # Priority order of this adapter over others
+    priority_order = 9999
+
+
+    def __init__(self, listing, context):
+        self.listing = listing
+        self.context = context
+
+    def before_render(self):
+        self.listing.columns["ProfileAnalyses"] = {
+            "title": _("Profile Analyses"),
+            "toggle": True,
+        }
+        for review_state in self.listing.review_states:
+            review_state["columns"] = self.listing.columns.keys()
+
+    def folder_item(self, obj, item, index):
+        profile = api.get_object(obj)
+        analyses = profile.getServices()
+        titles = map(api.get_title, analyses)
+        links = map(get_link_for, analyses)
+        item["ProfileAnalyses"] = ", ".join(titles)
+        item["replace"]["ProfileAnalyses"] = ", ".join(links)
+        return item

--- a/src/bes/lims/adapters/listing/configure.zcml
+++ b/src/bes/lims/adapters/listing/configure.zcml
@@ -8,4 +8,10 @@
     provides="senaite.app.listing.interfaces.IListingViewAdapter"
     factory=".samples.SamplesListingAdapter" />
 
+  <subscriber
+    for="senaite.core.browser.controlpanel.analysisprofiles.view.AnalysisProfilesView
+         *"
+    provides="senaite.app.listing.interfaces.IListingViewAdapter"
+    factory=".analysisprofiles.AnalysisProfilesListingAdapter" />
+
 </configure>


### PR DESCRIPTION
## Description
This PR add a new Profile Analyses column to the Analysis Profiles control panel listing
Linked issue: https://github.com/beyondessential/bes.lims/issues/120

## Current behavior
When exporting the Analysis Profiles list, there is no column showing which analyses belong to each profile

## Desired behavior
When exporting the Analysis Profiles list, include a new Profile Analyses column that lists all analyses in each profile

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
