### PR TITLE
Port BaseAnalysis ResultOptions schema to bes.lims

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0
 -----
 
+- #137 Port BaseAnalysis ResultOptions schema to bes.lims
 - #142 Replace Tamanu tasks queue PersistentList with OOBTree
 - #141 Tamanu integration: handle new tests added after ServiceRequest received
 - #140 Including the method where available in the Observation results to Tamanu

--- a/src/bes/lims/extender/baseanalysis.py
+++ b/src/bes/lims/extender/baseanalysis.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of BES.LIMS.
+#
+# BES.LIMS is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2024-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from archetypes.schemaextender.interfaces import IBrowserLayerAwareExtender
+from archetypes.schemaextender.interfaces import ISchemaModifier
+from bes.lims import messageFactory as _
+from bes.lims.interfaces import IBESLimsLayer
+from bika.lims import senaiteMessageFactory as _c
+from bika.lims.interfaces import IBaseAnalysis
+from Products.Archetypes import DisplayList
+from zope.component import adapter
+from zope.interface import implementer
+
+
+UPDATED_FIELDS = [
+    ("ResultOptions", {
+        "subfields": ("ResultValue", "ResultText", "AllowManualEntry", "Flag"),
+        "subfield_labels": {
+            "ResultValue": _c("Result Value"),
+            "ResultText": _c("Display Value"),
+            "AllowManualEntry": _c("Allow Manual Entry"),
+            "Flag": _("Flag"),
+        },
+        "subfield_types": {
+            "AllowManualEntry": "boolean",
+            "Flag": "selection",
+        },
+        "subfield_sizes": {
+            "AllowManualEntry": 8,
+            "Flag": 1,
+        },
+        "subfield_vocabularies": {
+            "Flag": DisplayList((
+                ("", ""),
+                ("negative", _("Negative")),
+                ("positive", _("Positive")),
+            )),
+        },
+    }),
+]
+
+
+def update_field(schema, field_id, field_info):
+    """Updates the schema field with the field_info provided
+    """
+    field = schema[field_id]
+    for prop_id, prop_value in field_info.items():
+        if not hasattr(field, prop_id):
+            continue
+        setattr(field, prop_id, prop_value)
+
+
+@adapter(IBaseAnalysis)
+@implementer(ISchemaModifier, IBrowserLayerAwareExtender)
+class BaseAnalysisSchemaModifier(object):
+    layer = IBESLimsLayer
+
+    def __init__(self, context):
+        self.context = context
+
+    def fiddle(self, schema):
+        for field_name, field_info in UPDATED_FIELDS:
+            update_field(schema, field_name, field_info)
+        return schema

--- a/src/bes/lims/extender/baseanalysis.zcml
+++ b/src/bes/lims/extender/baseanalysis.zcml
@@ -1,0 +1,9 @@
+<configure xmlns="http://namespaces.zope.org/zope">
+
+  <!-- Schema modifier for Service/Analysis-like types -->
+  <adapter
+      name="bes.lims.baseanalysis.schemamodifier"
+      provides="archetypes.schemaextender.interfaces.ISchemaModifier"
+      factory=".baseanalysis.BaseAnalysisSchemaModifier" />
+
+</configure>

--- a/src/bes/lims/extender/configure.zcml
+++ b/src/bes/lims/extender/configure.zcml
@@ -4,6 +4,7 @@
   <include package="archetypes.schemaextender"/>
 
   <!-- File includes -->
+  <include file="baseanalysis.zcml"/>
   <include file="client.zcml"/>
   <include file="setup.zcml"/>
   <include file="analysisrequest.zcml"/>


### PR DESCRIPTION
## Description
This PR Port `BaseAnalysis` `ResultOptions` schema customization from country add-ons into shared `bes.lims`, so all BES implementations use one centralized definition.

Linked issue: https://github.com/beyondessential/bes.lims/issues/117

## Current behavior
- `ResultOptions` schema customization is duplicated across multiple country add-ons (`bes.fnu`, `bes.nauru`, `bes.rmi`, `bes.samoa`, `bes.tonga`, `bes.tuvalu`).
- Each add-on registers its own `BaseAnalysisSchemaModifier` and maintains near-identical `content/baseanalysis.py`.
- Updating `ResultOptions` behavior requires touching multiple repositories/modules, increasing drift risk.


## Desired behavior
- `ResultOptions` schema is defined once in `bes.lims` and shared by all BES country add-ons.
- Country add-ons stop registering duplicate `BaseAnalysisSchemaModifier` implementations for this concern.
- Maintenance is simplified and behavior is consistent across BES deployments.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
