### PR TITLE
Including the method in the observations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 1.0.0
 -----
-- #135 Including the method where available in the Observation in results to Tamanu
+- #140 Including the method where available in the Observation results to Tamanu
 - #134 Include the name of the verifier when sending results to Tamanu
 - #131 Push FHIR Observations to Tamanu using a FHIR Transaction Bundle
 - #133 Add microbiology statistic reports for contamination, pathogen, AST panel, and sample rejection

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 1.0.0
 -----
-
+- #135 Including the method where available in the Observation in results to Tamanu
 - #134 Include the name of the verifier when sending results to Tamanu
 - #131 Push FHIR Observations to Tamanu using a FHIR Transaction Bundle
 - #133 Add microbiology statistic reports for contamination, pathogen, AST panel, and sample rejection

--- a/src/bes/lims/tamanu/tasks/diagnosticreport.py
+++ b/src/bes/lims/tamanu/tasks/diagnosticreport.py
@@ -11,6 +11,7 @@ from bes.lims.tamanu.config import LOINC_GENERIC_DIAGNOSTIC
 from bes.lims.tamanu.config import SAMPLE_STATUSES
 from bes.lims.tamanu.config import SENAITE_TESTS_CODING_SYSTEM
 from bes.lims.tamanu.config import SEND_OBSERVATIONS
+from bes.lims.tamanu.config import SNOMED_CODING_SYSTEM
 from bes.lims.tamanu.interfaces import ITamanuTask
 from bes.lims.tamanu.tasks import NOTIFY_DIAGNOSTIC_REPORT
 from bes.lims.tamanu.tasks import queue
@@ -205,6 +206,23 @@ class NotifyAdapter(object):
             observations.append((observation["id"], observation))
         return observations
 
+    def get_observation_method(self, analysis):
+        """Returns the method if one exists of the particular
+        Observation
+        """
+        method = analysis.getMethod()
+
+        # method.Title() is mandatory
+        if method and method.getMethodID():
+            return {
+                "coding": [{
+                    "system": SNOMED_CODING_SYSTEM,
+                    "code": method.getMethodID(),
+                    "display": method.Title(),
+                }]
+            }
+        return None
+
     def get_observation(self, analysis):
         """Returns a dict that represents a FHIR Observation counterpart of the
         analysis passed-in
@@ -243,6 +261,10 @@ class NotifyAdapter(object):
         performer = self.get_performer(analysis)
         if performer:
             observation["performer"] = performer
+
+        method = self.get_observation_method(analysis)
+        if method:
+            observation["method"] = method
 
         return observation
 


### PR DESCRIPTION
## Description

Linked issue: https://github.com/beyondessential/bes.lims/issues/135

## Current behaviour
Does not reference the method in the Observation

## Desired behaviour
Will include a method in the Observation:

```json
"resourceType": "Observation",
        "method": {
          "coding": [
            {
              "code": "708058007",
              "system": "http://snomed.info/sct",
              "display": "Fluorescence Flow Cytometry"
            }
          ]
        },

```


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
