### PR TITLE
Handle new tests added to Sample after ServiceRequest recieved

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 1.0.0
 -----
-
+- #101 Tamanu integration: handle new tests added after ServiceRequest received
 - #134 Include the name of the verifier when sending results to Tamanu
 - #131 Push FHIR Observations to Tamanu using a FHIR Transaction Bundle
 - #133 Add microbiology statistic reports for contamination, pathogen, AST panel, and sample rejection

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 1.0.0
 -----
-- #101 Tamanu integration: handle new tests added after ServiceRequest received
+- #141 Tamanu integration: handle new tests added after ServiceRequest received
 - #134 Include the name of the verifier when sending results to Tamanu
 - #131 Push FHIR Observations to Tamanu using a FHIR Transaction Bundle
 - #133 Add microbiology statistic reports for contamination, pathogen, AST panel, and sample rejection

--- a/src/bes/lims/tamanu/tasks/diagnosticreport.py
+++ b/src/bes/lims/tamanu/tasks/diagnosticreport.py
@@ -217,8 +217,15 @@ class NotifyAdapter(object):
         if not ordered_test:
             # Although not initially requested, we also report this analysis
             # and its result back to Tamanu as an Observation!
-            ordered_test = {"coding": []}
-
+            keyword = analysis.getKeyword()
+            name = api.get_title(analysis)
+            display = "%s | %s" % (keyword, name)
+            coding =  {
+                "code": keyword,
+                "system": SENAITE_TESTS_CODING_SYSTEM,
+                "display": display
+            }
+            ordered_test = {"coding": [coding]}
         # E.g. https://hl7.org/fhir/R4B/observation-example-f001-glucose.json.html
         status = api.get_review_status(analysis)
         status = dict(ANALYSIS_STATUSES).get(status, "partial")


### PR DESCRIPTION
## Description

Linked issue: https://github.com/beyondessential/bes.lims/issues/101

## Current behaviour
The Observation would return:
```
    "code": {
      "coding": []
    },
```

## Desired behaviour
It now looks up the keyword and returns:
```
"code": {
      "coding": [
        {
          "code": "COLD-AGG",
          "system": "https://www.senaite.com/testCodes.html",
          "display": "COLD-AGG | Cold Agglutination" // "Keyword | Title"
        }
      ]
    },
```
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
