### PR TITLE
Replace Tamanu tasks queue PersistentList with OOBTree

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Changelog
 
 1.0.0
 -----
+
+- #142 Replace Tamanu tasks queue PersistentList with OOBTree
 - #141 Tamanu integration: handle new tests added after ServiceRequest received
 - #140 Including the method where available in the Observation results to Tamanu
 - #134 Include the name of the verifier when sending results to Tamanu

--- a/src/bes/lims/profiles/default/metadata.xml
+++ b/src/bes/lims/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>1019</version>
+  <version>1020</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/bes/lims/tamanu/tasks/queue.py
+++ b/src/bes/lims/tamanu/tasks/queue.py
@@ -2,30 +2,34 @@
 
 import time
 
+from BTrees.OOBTree import OOBTree
 from bes.lims.tamanu import logger
 from bes.lims.tamanu.config import TAMANU_TASKS_QUEUE
 from bes.lims.tamanu.interfaces import ITamanuTask
 from bika.lims import api
 from bika.lims.decorators import synchronized
-from persistent.list import PersistentList
 from zope.annotation.interfaces import IAnnotations
 from zope.component import queryAdapter
 
 
 def _get_tasks():
-    """Returns a PersistentList containing a list of dicts, each representing
-    a Tamanu task, sorted reverse, from newest to oldest
+    """Returns an OOBTree of pending Tamanu tasks, keyed by task_id
+    (``"<uid>-<name>"``) with the scheduled-on epoch timestamp as value.
+
+    OOBTree is used (rather than a flat ``persistent.list.PersistentList``)
+    so concurrent producers inserting distinct keys do not generate
+    unresolvable ConflictErrors on the underlying persistent container.
     """
     portal = api.get_portal()
     annotation = IAnnotations(portal)
     if annotation.get(TAMANU_TASKS_QUEUE) is None:
-        annotation[TAMANU_TASKS_QUEUE] = PersistentList()
+        annotation[TAMANU_TASKS_QUEUE] = OOBTree()
     return annotation[TAMANU_TASKS_QUEUE]
 
 
 @synchronized(max_connections=1)
 def get():
-    """Pops the next task to be processed
+    """Pops the next task whose scheduled time has elapsed
     """
     # get the tasks
     tasks = _get_tasks()
@@ -33,26 +37,25 @@ def get():
     # current time in seconds since the epoch
     now = int(time.time())
 
-    # first elements added have priority (FIFO)
-    task = None
-    for idx in range(len(tasks)):
-        # check if the task has to be delayed
-        if tasks[idx][1] <= now:
-            task = tasks.pop(idx)[0]
+    task_id = None
+    for tid, when in tasks.items():
+        if when <= now:
+            task_id = tid
             break
 
-    # no task found
-    if not task:
+    if not task_id:
         return None
 
+    del tasks[task_id]
+
     # get the name of the task and the context uid
-    idx = task.index("-")
-    uid = task[:idx]
-    name = task[idx+1:]
+    idx = task_id.index("-")
+    uid = task_id[:idx]
+    name = task_id[idx+1:]
 
     # validate the task id
     if not all([name, api.is_uid(uid)]):
-        logger.error("Not a valid task: %s" % task)
+        logger.error("Not a valid task: %s" % task_id)
         return None
 
     # get the context
@@ -67,7 +70,7 @@ def get():
 
 @synchronized(max_connections=1)
 def put(name, context, delay=120):
-    """Appends a task for the given name and context to the queue
+    """Adds a task for the given name and context to the queue
     :param name: The name of the task
     :param context: Context the task is bound to
     :param delay: Minimum delay in seconds before the task is executed
@@ -78,9 +81,8 @@ def put(name, context, delay=120):
     task_id = "%s-%s" % (uid, name)
     tasks = _get_tasks()
 
-    # do not append unless new
-    ids = [task[0] for task in tasks]
-    if task_id in ids:
+    # do not add unless new
+    if task_id in tasks:
         return False
 
     # current time in seconds since the epoch + delay
@@ -88,5 +90,5 @@ def put(name, context, delay=120):
 
     # add the task
     logger.info("Task %s [scheduled on %s]" % (task_id, when))
-    tasks.append((task_id, when))
+    tasks[task_id] = when
     return True

--- a/src/bes/lims/upgrade/v01_00_000.py
+++ b/src/bes/lims/upgrade/v01_00_000.py
@@ -21,6 +21,7 @@
 import copy
 import transaction
 
+from BTrees.OOBTree import OOBTree
 from bes.lims import PRODUCT_NAME as product
 from bes.lims import logger
 from bes.lims.setuphandlers import setup_behaviors
@@ -31,8 +32,10 @@ from bes.lims.setuphandlers import setup_roles
 from bes.lims.setuphandlers import setup_workflows
 from bes.lims.setuphandlers import WORKFLOWS_TO_UPDATE
 from bes.lims.tamanu import api as tapi
+from bes.lims.tamanu.config import TAMANU_TASKS_QUEUE
 from bes.lims.tamanu.interfaces import ITamanuContent
 from bika.lims import api
+from persistent.list import PersistentList
 from Products.ZCatalog.ProgressHandler import ZLogHandler
 from senaite.core.api import workflow as wapi
 from senaite.core.catalog import ANALYSIS_CATALOG
@@ -48,6 +51,7 @@ from senaite.core.workflow import DUPLICATE_ANALYSIS_WORKFLOW
 from senaite.core.workflow import REFERENCE_ANALYSIS_WORKFLOW
 from senaite.core.workflow import SAMPLE_WORKFLOW
 from zope import component
+from zope.annotation.interfaces import IAnnotations
 from zope.interface import alsoProvides
 from zope.schema.interfaces import IVocabularyFactory
 
@@ -540,3 +544,32 @@ def setup_tamanu_host_credentials(tool):
     setup = portal.portal_setup
     setup.runImportStepFromProfile(profile, "plone.app.registry")
     logger.info("Setup Tamanu host and credentials [DONE]")
+
+
+def migrate_tamanu_queue_to_btree(tool):
+    """Migrates the Tamanu tasks queue annotation from PersistentList to
+    OOBTree. The previous container conflicted on every concurrent producer
+    because PersistentList has no `_p_resolveConflict`; OOBTree merges
+    non-overlapping inserts via its built-in resolver.
+    """
+    logger.info("Migrate Tamanu tasks queue to OOBTree ...")
+    portal = api.get_portal()
+    annotation = IAnnotations(portal)
+    existing = annotation.get(TAMANU_TASKS_QUEUE)
+    if isinstance(existing, OOBTree):
+        logger.info("Tamanu tasks queue is already an OOBTree [SKIP]")
+        return
+
+    new_queue = OOBTree()
+    if isinstance(existing, PersistentList):
+        for entry in existing:
+            # entries used to be (task_id, when) tuples
+            try:
+                task_id, when = entry
+            except (TypeError, ValueError):
+                logger.warn("Skipping malformed queue entry: %r" % (entry,))
+                continue
+            new_queue[task_id] = when
+
+    annotation[TAMANU_TASKS_QUEUE] = new_queue
+    logger.info("Migrate Tamanu tasks queue to OOBTree [DONE]")

--- a/src/bes/lims/upgrade/v01_00_000.zcml
+++ b/src/bes/lims/upgrade/v01_00_000.zcml
@@ -3,6 +3,19 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="Migrate Tamanu tasks queue to OOBTree"
+      description="
+        Replaces the PersistentList container used as the Tamanu tasks queue
+        with an OOBTree. The previous container had no conflict resolver, so
+        concurrent producers (e.g. publishing samples on different clients)
+        generated unresolvable ConflictErrors on the portal annotation.
+      "
+      source="1019"
+      destination="1020"
+      handler=".v01_00_000.migrate_tamanu_queue_to_btree"
+      profile="bes.lims:default"/>
+
+  <genericsetup:upgradeStep
       title="Add Tamanu host and credentials to control panel"
       description="
         Registers the new host, email and password fields of the Tamanu


### PR DESCRIPTION
The Tamanu tasks queue is stored as a `persistent.list.PersistentList` annotation on the portal root (key `senaite.tamanu.queue.storage`). Every published sample appends a `(task_id, when)` tuple to this single container via `bes.lims.tamanu.tasks.queue.put()`, which is invoked from `subscribers/resultsreport.py::on_object_created` and `subscribers/sample.py::on_published`.

`PersistentList` has no `_p_resolveConflict`, so when two ZEO clients each append to the queue in their own transaction and reach `tpc_vote` together, ZODB cannot merge the pickles. The conflict propagates up through the request retry budget and surfaces to the end user as an "Oops" page during publishing.

Evidence in production: the queue's OID is the first hot-conflict OID over the last 30 days of ZEO logs on a Tamanu-integrated deployment (79 occurrences in a 30-day window, far ahead of any normal BTrees bucket conflict).

## Current behavior

- Concurrent publishes from different ZEO clients each append to the same `PersistentList`.
- The second commit raises `ZODB.POSException.ConflictError (class persistent.list.PersistentList)`.
- ZODB retries the transaction; the retry attempts the same append and conflicts again. After the retry budget is exhausted the user sees an "Oops" error.

## Desired behavior

- The queue is an `OOBTree` keyed by `task_id` with `when` as value.
- Concurrent inserts of different keys merge silently via the BTree bucket resolver — no user-visible failure.
- Duplicate enqueue is still a no-op (`task_id in tasks`).
- `get()` returns the first task whose scheduled time has elapsed, with the same delay semantics as before.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
