### PR TITLE
Updated the Observations to handle quantitative reference ranges

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changelog
 
 1.0.0
 -----
+- #144 Adding reference results to Tamanu FHIR Observations
 - #141 Tamanu integration: handle new tests added after ServiceRequest received
 - #140 Including the method where available in the Observation results to Tamanu
 - #134 Include the name of the verifier when sending results to Tamanu

--- a/src/bes/lims/tamanu/tasks/diagnosticreport.py
+++ b/src/bes/lims/tamanu/tasks/diagnosticreport.py
@@ -263,6 +263,9 @@ class NotifyAdapter(object):
                 "value": analysis.getResult(),
                 "unit": analysis.getUnit(),
             }
+            reference_range = self.get_reference_range(analysis)
+            if reference_range:
+                observation["referenceRange"] = reference_range
 
         # assign the person who verified the analysis (performer)
         performer = self.get_performer(analysis)
@@ -330,6 +333,44 @@ class NotifyAdapter(object):
                 "value": user_id,
             }
         }]
+
+    def get_reference_range(self, analysis):
+        """This will return a FHIR Observation's reference range for a
+        quantitative analysis.
+        """
+        # including this duplicated check in case function is reused
+        if analysis.getStringResult() or analysis.getResultOptions():
+            # qualitative not quantitative
+            return None
+        # Qualitative
+        results_range = analysis.getResultsRange()
+
+        if not results_range:
+            return None
+        low = results_range.get('min')
+        high = results_range.get('max')
+
+        if not low and not high:
+            return None
+
+        reference_range = {}
+        if low:
+            reference_range['low'] = {
+                'value': float(low),
+                'unit': analysis.getUnit(),
+                'system': 'http://unitsofmeasure.org',
+                'code': analysis.getUnit(),
+            }
+
+        if high:
+            reference_range['high'] = {
+                'value': float(high),
+                'unit': analysis.getUnit(),
+                'system': 'http://unitsofmeasure.org',
+                'code': analysis.getUnit(),
+            }
+
+        return [reference_range]
 
 
 def can_notify(sample):


### PR DESCRIPTION
## Description

Linked issue: https://github.com/beyondessential/bes.lims/issues/109

## Current behaviour
No reference ranges coming through in the diagnostic report's Observations

## Desired behaviour
Reference ranges are now coming through like this:
```
"resource": {
        "status": "final",
        "code": {
          "text": "MCV",
          "coding": [
            {
              "code": "MCV",
              "system": "https://www.senaite.com/testCodes.html",
              "display": "MCV"
            },
            {
              "code": "external-labTestType-MCV",
              "system": "http://loinc.org",
              "display": "MCV"
            }
          ]
        },
        "resourceType": "Observation",
        "referenceRange": [
          {
            "high": {
              "code": "fL",
              "unit": "fL",
              "value": 100.0,
              "system": "http://unitsofmeasure.org"
            },
            "low": {
              "code": "fL",
              "unit": "fL",
              "value": 80.0,
              "system": "http://unitsofmeasure.org"
            }
          }
        ],
        "valueQuantity": {
          "unit": "fL",
          "value": "101"
        },
        "performer": [
          {
            "identifier": {
              "value": "Labman1"
            },
            "display": "Lab Manager 1"
          }
        ],
        "id": "9bf50ab5-5562-45a0-9d0d-92b96705eb41"
      },
```

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
