### PR TITLE
Support DynamicAnalysisSpec range comment text for 0/0 ranges

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0
 -----
 
+- #146 Support DynamicAnalysisSpec range comment text for 0/0 ranges
 - #142 Replace Tamanu tasks queue PersistentList with OOBTree
 - #141 Tamanu integration: handle new tests added after ServiceRequest received
 - #140 Including the method where available in the Observation results to Tamanu

--- a/src/bes/lims/browser/sample/analyses.py
+++ b/src/bes/lims/browser/sample/analyses.py
@@ -107,13 +107,14 @@ class SampleAnalysesListingAdapter(object):
         """
         analysis = self.listing.get_object(obj)
 
-        # use listing's default if value for max is above 0
+        # Show textual range comments only for 0/0 sentinel ranges
         specs = analysis.getResultsRange()
+        range_min = api.to_float(specs.get("min"), default=0)
         range_max = api.to_float(specs.get("max"), default=0)
-        if range_max > 0:
+        if range_min != 0 or range_max != 0:
             return
 
-        # no value set for neither min nor max, show the range comment
+        # no numeric range set, show the range comment if any
         comment = specs.get("rangecomment")
         if comment:
             item["replace"]["Specification"] = comment

--- a/src/bes/lims/impress/reportview.py
+++ b/src/bes/lims/impress/reportview.py
@@ -305,8 +305,9 @@ class DefaultReportView(SingleReportView):
         returns the value entered into "Out of range comment" field
         """
         specs = analysis.getResultsRange()
+        range_min = api.to_float(specs.get("min"), default=0)
         range_max = api.to_float(specs.get("max"), default=0)
-        if range_max > 0:
+        if range_min != 0 or range_max != 0:
             return model.get_formatted_specs(analysis)
         return specs.get("rangecomment")
 

--- a/src/bes/lims/patches/configure.zcml
+++ b/src/bes/lims/patches/configure.zcml
@@ -1,6 +1,7 @@
 <configure xmlns="http://namespaces.zope.org/zope">
 
   <!-- Package includes -->
+  <include package=".dynamicresultsrange"/>
   <include package=".beka"/>
   <include package=".vocabularies"/>
 

--- a/src/bes/lims/patches/dynamicresultsrange/__init__.py
+++ b/src/bes/lims/patches/dynamicresultsrange/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of BES.LIMS.
+#
+# BES.LIMS is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2024-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.

--- a/src/bes/lims/patches/dynamicresultsrange/configure.zcml
+++ b/src/bes/lims/patches/dynamicresultsrange/configure.zcml
@@ -1,0 +1,10 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:monkey="http://namespaces.plone.org/monkey">
+
+  <monkey:patch
+      class="bika.lims.adapters.dynamicresultsrange.DynamicResultsRange"
+      original="get_results_range"
+      replacement=".rangecomment.get_results_range" />
+
+</configure>

--- a/src/bes/lims/patches/dynamicresultsrange/rangecomment.py
+++ b/src/bes/lims/patches/dynamicresultsrange/rangecomment.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of BES.LIMS.
+#
+# BES.LIMS is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2024-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.lims import api
+from bika.lims.adapters.dynamicresultsrange import marker
+
+
+def get_results_range(self):
+    """Return dynamic range values and preserve textual `rangecomment`."""
+    if self.dynamicspec is None:
+        return {}
+
+    # A matching Analysis Keyword is mandatory for any further matches
+    keyword = self.analysis.getKeyword()
+    by_keyword = self.dynamicspec.get_by_keyword()
+
+    # Get all specs (rows) from the Excel with the same Keyword
+    specs = by_keyword.get(keyword)
+    if not specs:
+        return {}
+
+    # Filter those with a match
+    specs = filter(self.match, specs)
+    if not specs:
+        return {}
+
+    # Sort them and pick the first match, that is less generic
+    spec = sorted(specs, cmp=self.cmp_specs)[0]
+
+    # at this point we have a match, update the results range dict
+    rr = {}
+    for key in self.range_keys:
+        value = spec.get(key, marker)
+        # skip if the range key is not set in the Excel
+        if value is marker:
+            continue
+        # skip if the value is not floatable
+        if not api.is_floatable(value):
+            continue
+        rr[key] = value
+
+    # Support both "rangecomment" and "Range comment" XLSX headers
+    comment = spec.get("rangecomment") or spec.get("Range comment")
+    if comment and api.is_string(comment):
+        rr["rangecomment"] = comment.strip()
+
+
+    # return the updated result range
+    return rr


### PR DESCRIPTION
## Description
Add support for DynamicAnalysisSpec range comment text from XLSX in bes.lims, so users can define textual interpretation for zero ranges

Linked issue: https://github.com/beyondessential/bes.lims/issues/127

## Current behavior
When DynamicAnalysisSpec rows use `min=0` and `max=0`, SENAITE still displays the numeric interval ([0;0] / equivalent formatted range).
Even if a comment is present in XLSX (e.g. `Range comment`), it is not shown as the normal value text in BES views/reports.

## Desired behavior
When a DynamicAnalysisSpec row has `min=0` and `max=0` and includes a comment (`rangecomment` or `Range comment` in XLSX), we should display the comment text instead of a numeric `[0;0]` range in normal values output

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
