### PR TITLE
Only send verified or published analyses to Tamanu

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0
 -----
 
+- #148 Only send verified or published analyses to Tamanu
 - #142 Replace Tamanu tasks queue PersistentList with OOBTree
 - #141 Tamanu integration: handle new tests added after ServiceRequest received
 - #140 Including the method where available in the Observation results to Tamanu

--- a/src/bes/lims/tamanu/tasks/diagnosticreport.py
+++ b/src/bes/lims/tamanu/tasks/diagnosticreport.py
@@ -200,6 +200,12 @@ class NotifyAdapter(object):
             if not is_reportable(analysis):
                 # skip non-reportable samples
                 continue
+
+            # only report analyses that are either verified or published
+            status = api.get_review_status(analysis)
+            if status not in ["verified", "published"]:
+                continue
+
             # get the representation of the analysis as a FHIR Observation
             observation = self.get_observation(analysis)
             # append the observations


### PR DESCRIPTION
## Description

Linked issue: #145
## Current behavior

When SENAITE notifies Tamanu via DiagnosticReport, every analysis considered "reportable" by `bes.lims.utils.is_reportable` is pushed. That helper accepts `to_be_verified`, `verified`, `published` and `out_of_stock` (see `bes/lims/config.py:ANALYSIS_REPORTABLE_STATUSES`), so interfaced-instrument results can reach Tamanu before a verifier has reviewed them. Clinicians may then act on results that the lab has not yet validated.
 
## Desired behavior

`NotifyAdapter.get_observations()` filters out any analysis whose review status is not `verified` or `published` before building the FHIR Observations payload. Analyses still in `to_be_verified` (or `out_of_stock`) are no longer included in the bundle sent to Tamanu. The general-purpose `is_reportable()` is left untouched so that internal results reports keep their existing behavior; only the Tamanu notification path is tightened.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
